### PR TITLE
Differentiate between adding constraints and laying out subtree

### DIFF
--- a/Cartography/Layout.swift
+++ b/Cartography/Layout.swift
@@ -8,31 +8,50 @@
 
 import Foundation
 
-public func layout(view: View, block: LayoutProxy -> ()) {
+/// Adds constraints from `block` to the given view
+public func constrain(view: View, block: LayoutProxy -> ()) {
     block(LayoutProxy(view))
+}
 
-    view.car_updateAutoLayoutConstraints()
+/// Adds constraints from `block` to the given view & forces a layout pass before returning
+public func layout(view: View, block: LayoutProxy -> ()) {
+    constrain(view, block)
+
+    view.car_updateLayout()
+}
+
+public func constrain(v1: View, v2: View, block: (LayoutProxy, LayoutProxy) -> ()) {
+    block(LayoutProxy(v1), LayoutProxy(v2))
 }
 
 public func layout(v1: View, v2: View, block: (LayoutProxy, LayoutProxy) -> ()) {
-    block(LayoutProxy(v1), LayoutProxy(v2))
+    constrain(v1, v2, block)
 
-    v1.car_updateAutoLayoutConstraints()
-    v2.car_updateAutoLayoutConstraints()
+    v1.car_updateLayout()
+    v2.car_updateLayout()
+}
+
+public func constrain(v1: View, v2: View, v3: View, block: (LayoutProxy, LayoutProxy, LayoutProxy) -> ()) {
+    block(LayoutProxy(v1), LayoutProxy(v2), LayoutProxy(v3))
+
 }
 
 public func layout(v1: View, v2: View, v3: View, block: (LayoutProxy, LayoutProxy, LayoutProxy) -> ()) {
-    block(LayoutProxy(v1), LayoutProxy(v2), LayoutProxy(v3))
+    constrain(v1, v2, v3, block)
 
-    v1.car_updateAutoLayoutConstraints()
-    v2.car_updateAutoLayoutConstraints()
-    v3.car_updateAutoLayoutConstraints()
+    v1.car_updateLayout()
+    v2.car_updateLayout()
+    v3.car_updateLayout()
+}
+
+public func constrain(views: [View], block:([LayoutProxy]) -> ()) {
+    block(views.map({ LayoutProxy($0) }))
 }
 
 public func layout(views: [View], block:([LayoutProxy]) -> ()) {
-    block(views.map({ LayoutProxy($0) }))
+    constrain(views, block)
 
     for view in views {
-        view.car_updateAutoLayoutConstraints()
+        view.car_updateLayout()
     }
 }

--- a/Cartography/View.swift
+++ b/Cartography/View.swift
@@ -13,7 +13,7 @@ import Foundation
     public typealias View = UIView
 
     extension View {
-        func car_updateAutoLayoutConstraints() {
+        func car_updateLayout() {
             layoutIfNeeded()
         }
 
@@ -26,7 +26,7 @@ import Foundation
     public typealias View = NSView
 
     extension View {
-        func car_updateAutoLayoutConstraints() {
+        func car_updateLayout() {
             superview?.layoutSubtreeIfNeeded()
         }
 


### PR DESCRIPTION
Callers may not want to cause a layout pass when adding constraints; `layout` maintains the previous behavior, but calling `constrain` opts out of calling `layoutIfNeeded`/`layoutSubtreeIfNeeded`.

(Calling `layout` from `init(frame: CGRectZero())` gave us unsatisfiable constraints warnings until the view was added to a window and given a width/height; `constrain` is safe to call before a view is added to a hierarchy.)
