### PR TITLE
Add "^" postfix operator to LayoutProxy to ease access to superview

### DIFF
--- a/Cartography/LayoutProxy.swift
+++ b/Cartography/LayoutProxy.swift
@@ -68,6 +68,6 @@ public class LayoutProxy {
 
 postfix operator ^ {}
 
-postfix func ^ (inout proxy: LayoutProxy) -> LayoutProxy? {
-    return proxy.superview
+postfix func ^ (inout proxy: LayoutProxy) -> LayoutProxy {
+    return proxy.superview!
 }


### PR DESCRIPTION
I was annoyed by typing "superview" all the time
