### PR TITLE
Add a dictionary variation of layout and constrain functions.

### DIFF
--- a/Cartography/Layout.swift
+++ b/Cartography/Layout.swift
@@ -40,7 +40,7 @@ public func layout(views: [View], block:([LayoutProxy]) -> ()) {
     context.installConstraints()
 }
 
-public func layout(views: [String : View], block:([String : LayoutProxy] -> ())) {
+public func layout<T: Hashable>(views: [T: View], block:([T : LayoutProxy] -> ())) {
     let context = Context(performLayout: true)
     let result = map(views) { ($0, LayoutProxy(context, $1)) }
     
@@ -81,7 +81,7 @@ public func constrain(views: [View], block:([LayoutProxy]) -> ()) {
     context.installConstraints()
 }
 
-public func constrain(views: [String : View], block:([String : LayoutProxy] -> ())) {
+public func constrain<T: Hashable>(views: [T: View], block:([T : LayoutProxy] -> ())) {
     let context = Context(performLayout: true)
     let result = map(views) { ($0, LayoutProxy(context, $1)) }
     


### PR DESCRIPTION
This fixes #43.

I'm conflicted about weather or not we should remove the `Array` based versions now that we have a `Dictionary` version. On one hand we should keep the `Array` version as it is:
- More Succinct
- Doesn't return an optional when accessing the value, while `Dictionary` does.
- Doesn't break the API

On the other hand:
- The public API grows.
- The intent of both the `Array` and `Dictionary` based versions are essentially the same. Meaning that as it stands now we are solving the same problem in two different ways, which is concerning.

One more thing, I decided to target the refactor branch because I thought the implementation might change dramatically between refactor and master (turns out, that it didn't really matter), and because it's the branch that I'm using.
