### PR TITLE
Add Swift podspec

### DIFF
--- a/Cartography.podspec
+++ b/Cartography.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.author       = { "Robert Böhnke" => "robb@robb.is" }
   s.ios.deployment_target = "8.0"
 
-  s.source = { :git => "https://github.com/robb/Cartography.git", :commit => "2a85b80ad0f7abc80ab520a6b665be9f88603b2c" }
+  s.source = { :git => "https://github.com/robb/Cartography.git", :tag => "#{s.version}" }
   s.source_files  = "Cartography/*.swift"
 
   s.requires_arc = true

--- a/Cartography.podspec
+++ b/Cartography.podspec
@@ -1,0 +1,21 @@
+Pod::Spec.new do |s|
+
+  s.name         = "Cartography"
+  s.version      = "0.1.0"
+  s.summary      = "Declarative Auto Layout in Swift"
+
+  s.description  = <<-DESC
+                   Set up your Auto Layout constraints declaratively and without any stringly typing!
+                   DESC
+
+  s.homepage     = "https://github.com/robb/Cartography"
+  s.license      = { :type => "MIT", :file => "LICENSE" }
+  s.author       = { "Robert Böhnke" => "robb@robb.is" }
+  s.ios.deployment_target = "8.0"
+
+  s.source = { :git => "https://github.com/robb/Cartography.git", :commit => "2a85b80ad0f7abc80ab520a6b665be9f88603b2c" }
+  s.source_files  = "Cartography/*.swift"
+
+  s.requires_arc = true
+
+end


### PR DESCRIPTION
## Cocoapods support!
Added podspec to make it compatible with Cocoapods 0.36.0.beta.1.

Right now we can use 
````
pod "Cartography", :git => "https://github.com/DJBen/Cartography.git"
````
to install Cartography through cocoapods.
In order for cocoapods to find this project, we need to submit a spec in repo "Specs".

## Issues to address
1. You don't have any tags for this project, so I have to specify a commit version like
````ruby
 s.source = { :git => "https://github.com/robb/Cartography.git", :commit => "2a85b80ad0f7abc80ab520a6b665be9f88603b2c" }
````
which is not recommended (and will generate a warning during podspec validation). I temporarily make this version 0.1.0. Feel free to modify at your convenience.
2. I can't make it through podspec validation if I add the OS X deployment target version. It always complains about a compilation error. Also I set the iOS target version to 8.0 for safety, but maybe it can be used in 7.1 or earlier. 

Overall, this effort is just to make it work and embrace our good old cocoapods again.
Thank you for your comments and suggestions.