### PR TITLE
Add support for update existing constraint from `install()`.

### DIFF
--- a/Cartography.xcodeproj/project.pbxproj
+++ b/Cartography.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		036472C61A5F9B1A00E1F188 /* UpdateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 036472C41A5F96E700E1F188 /* UpdateTests.swift */; };
+		036472C71A5F9B1D00E1F188 /* UpdateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 036472C41A5F96E700E1F188 /* UpdateTests.swift */; };
 		545F858D195322EA00791F75 /* Edges.swift in Sources */ = {isa = PBXBuildFile; fileRef = 545F858C195322EA00791F75 /* Edges.swift */; };
 		545F858F1953235F00791F75 /* EdgesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 545F858E1953235F00791F75 /* EdgesTests.swift */; };
 		546E9E891950A29300B16707 /* LayoutProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 546E9E881950A29300B16707 /* LayoutProxy.swift */; };
@@ -87,6 +89,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		036472C41A5F96E700E1F188 /* UpdateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UpdateTests.swift; sourceTree = "<group>"; };
 		545F858C195322EA00791F75 /* Edges.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Edges.swift; sourceTree = "<group>"; };
 		545F858E1953235F00791F75 /* EdgesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EdgesTests.swift; sourceTree = "<group>"; };
 		546E9E881950A29300B16707 /* LayoutProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LayoutProxy.swift; sourceTree = "<group>"; };
@@ -216,6 +219,7 @@
 				54FA3A371950FD8E0094B82A /* OperatorTests.swift */,
 				54FA3A3D1951A3750094B82A /* PointTests.swift */,
 				54FA3A431951A9730094B82A /* SizeTests.swift */,
+				036472C41A5F96E700E1F188 /* UpdateTests.swift */,
 				BB41A06E1A229BF7007142FE /* ViewHierarchyTests.swift */,
 				54C96A21195063CD000CDD27 /* Supporting Files */,
 			);
@@ -437,6 +441,7 @@
 				546E9EA21950B33D00B16707 /* DimensionTests.swift in Sources */,
 				BBAC6D191A22A79900E8A3E2 /* ViewUtils.swift in Sources */,
 				546E9E931950A87600B16707 /* EdgeTests.swift in Sources */,
+				036472C61A5F9B1A00E1F188 /* UpdateTests.swift in Sources */,
 				BBAC6D1B1A22A8F300E8A3E2 /* ViewHierarchyTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -476,6 +481,7 @@
 				54F6A85E195C213F00313D24 /* EdgeTests.swift in Sources */,
 				54F6A85D195C213F00313D24 /* DimensionTests.swift in Sources */,
 				54F6A861195C213F00313D24 /* SizeTests.swift in Sources */,
+				036472C71A5F9B1D00E1F188 /* UpdateTests.swift in Sources */,
 				54F6A85F195C213F00313D24 /* EdgesTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Cartography/Constraint.swift
+++ b/Cartography/Constraint.swift
@@ -49,6 +49,9 @@ internal class Constraint {
             return false
         }
 
+        // store view who has set `firstView`'s constarint
+        (layoutConstraint.firstItem as View).car_increaseReferenceCountForView(view)
+
         view.addConstraint(layoutConstraint)
         return true
     }
@@ -64,6 +67,7 @@ internal class Constraint {
                 }
             }
         }
+        (layoutConstraint.firstItem as View).car_decreaseReferenceCountForView(view)
     }
 
     init(view: View, layoutConstraint: NSLayoutConstraint) {
@@ -72,16 +76,18 @@ internal class Constraint {
     }
 
     func layoutConstraintsSimilarTo(layoutConstraint: NSLayoutConstraint) -> Constraint? {
-        view
-        if let existings = view.car_installedLayoutConstraints {
-            for existing in existings {
-                if (existing.layoutConstraint.firstItem === layoutConstraint.firstItem &&
-                    existing.layoutConstraint.firstAttribute == layoutConstraint.firstAttribute &&
-                    existing.layoutConstraint.relation == layoutConstraint.relation) {
-                    return existing
-                }
+        var existings = view.car_installedLayoutConstraints ?? []
+        for referredView in (layoutConstraint.firstItem as View).car_referredViews {
+            existings += referredView.car_installedLayoutConstraints ?? []
+        }
+        for existing in existings {
+            if (existing.layoutConstraint.firstItem === layoutConstraint.firstItem &&
+                existing.layoutConstraint.firstAttribute == layoutConstraint.firstAttribute &&
+                existing.layoutConstraint.relation == layoutConstraint.relation) {
+                return existing
             }
         }
+
         return nil
     }
 }

--- a/Cartography/Constraint.swift
+++ b/Cartography/Constraint.swift
@@ -17,16 +17,71 @@ internal class Constraint {
     let view: View
     let layoutConstraint: NSLayoutConstraint
 
-    func install() {
+    /// return whether the constraint newely installed
+    func install() -> Bool {
+        if let existing = self.layoutConstraintsSimilarTo(self.layoutConstraint) {
+            // if exactly same with existing, do nothing
+            if (existing.layoutConstraint.secondItem === layoutConstraint.secondItem &&
+                existing.layoutConstraint.secondAttribute == layoutConstraint.secondAttribute &&
+                existing.layoutConstraint.constant == layoutConstraint.constant &&
+                existing.layoutConstraint.priority == layoutConstraint.priority &&
+                existing.layoutConstraint.multiplier == layoutConstraint.multiplier) {
+                return false
+            }
+
+            // if readonly properties differ from existing, reinstall
+            if (existing.layoutConstraint.secondItem !== layoutConstraint.secondItem ||
+                existing.layoutConstraint.secondAttribute != layoutConstraint.secondAttribute ||
+                existing.layoutConstraint.multiplier != layoutConstraint.multiplier) {
+                existing.uninstall()
+                view.addConstraint(layoutConstraint)
+                return true
+            }
+
+            // just update
+            if existing.layoutConstraint.constant != layoutConstraint.constant {
+                existing.layoutConstraint.constant = layoutConstraint.constant
+            }
+            if existing.layoutConstraint.priority != layoutConstraint.priority {
+                existing.layoutConstraint.priority = layoutConstraint.priority
+            }
+            view.car_setNeedsLayout()
+            return false
+        }
+
         view.addConstraint(layoutConstraint)
+        return true
     }
 
     func uninstall() {
         view.removeConstraint(layoutConstraint)
+        if var existings = view.car_installedLayoutConstraints {
+            for (i, existing) in enumerate(existings) {
+                if existing === self {
+                    existings.removeAtIndex(i)
+                    view.car_installedLayoutConstraints = existings
+                    break
+                }
+            }
+        }
     }
 
     init(view: View, layoutConstraint: NSLayoutConstraint) {
         self.view = view
         self.layoutConstraint = layoutConstraint
+    }
+
+    func layoutConstraintsSimilarTo(layoutConstraint: NSLayoutConstraint) -> Constraint? {
+        view
+        if let existings = view.car_installedLayoutConstraints {
+            for existing in existings {
+                if (existing.layoutConstraint.firstItem === layoutConstraint.firstItem &&
+                    existing.layoutConstraint.firstAttribute == layoutConstraint.firstAttribute &&
+                    existing.layoutConstraint.relation == layoutConstraint.relation) {
+                    return existing
+                }
+            }
+        }
+        return nil
     }
 }

--- a/Cartography/Context.swift
+++ b/Cartography/Context.swift
@@ -62,11 +62,11 @@ public class Context {
         let views = constraints.map({ $0.view })
 
         for constraint in constraints {
-            constraint.install()
-
-            let existing = constraint.view.car_installedLayoutConstraints ?? []
-
-            constraint.view.car_installedLayoutConstraints = existing + [ constraint ]
+            let installed = constraint.install()
+            if installed {
+                let existing = constraint.view.car_installedLayoutConstraints ?? []
+                constraint.view.car_installedLayoutConstraints = existing + [ constraint ]
+            }
         }
 
         if performLayout {

--- a/Cartography/View.swift
+++ b/Cartography/View.swift
@@ -13,6 +13,10 @@ import Foundation
     public typealias View = UIView
 
     extension View {
+        func car_setNeedsLayout() {
+            setNeedsLayout()
+        }
+
         func car_updateLayout() {
             layoutIfNeeded()
         }
@@ -26,6 +30,10 @@ import Foundation
     public typealias View = NSView
 
     extension View {
+        func car_setNeedsLayout() {
+            needsLayout = true
+        }
+
         func car_updateLayout() {
             (superview ?? self).layoutSubtreeIfNeeded()
         }

--- a/CartographyTests/UpdateTests.swift
+++ b/CartographyTests/UpdateTests.swift
@@ -1,0 +1,56 @@
+//
+//  UpdateTests.swift
+//  CartographyTests
+//
+//  Created by Suyeol Jeon on 09/01/15.
+//  Copyright (c) 2014 Robert Böhnke. All rights reserved.
+//
+
+import Cartography
+import XCTest
+
+class UpdateTests: XCTestCase {
+    var superview: View!
+    var view1: View!
+    var view2: View!
+
+    override func setUp() {
+        superview = View(frame: CGRectMake(0, 0, 400, 400))
+
+        view1 = View(frame: CGRectMake(0, 0, 400, 400))
+        superview.addSubview(view1)
+
+        view2 = View(frame: CGRectMake(0, 0, 150, 200))
+        superview.addSubview(view2)
+    }
+
+    func testUpdate1() {
+        layout(view1) { view1 in
+            view1.width  == 100
+            view1.height == 100
+        }
+
+        layout(view1, view2) { (view1, view2) in
+            view1.width  == view2.width  + 200
+            view1.height == view2.height + 200
+        }
+
+        XCTAssert(CGRectGetWidth(view1.frame) == CGRectGetWidth(view2.frame) + 200, "It should update existing constraint")
+        XCTAssert(CGRectGetHeight(view1.frame) == CGRectGetHeight(view2.frame) + 200, "It should update existing constraint")
+    }
+
+    func testUpdate2() {
+        layout(view1, view2) { (view1, view2) in
+            view1.width  == view2.width  + 200
+            view1.height == view2.height + 200
+        }
+
+        layout(view1) { view1 in
+            view1.width  == 100
+            view1.height == 100
+        }
+
+        XCTAssert(CGRectGetWidth(view1.frame) == 100, "It should update existing constraint")
+        XCTAssert(CGRectGetHeight(view1.frame) == 100, "It should update existing constraint")
+    }
+}


### PR DESCRIPTION
Concept
-------

### 1. Update constant

If the new constraint is exactly the same with existing, `layout()` will just update a constant of existing constraint.

```swift
layout(view) { view in
    view.top == view.superview!.top + 10
    view.left == view.superview!.left + 10
    view.width == 200
}

// just update constants
layout(view) { view in
    view.top == view.superview!.top + 20
    view.width == 300
}
```

### 2. Replace existing constraint

If the new constraint has different relation from existing, `layout()` will uninstall existing and install the new one.

```swift
layout(view) { view in
    view.left == someView.top.left + 10
}

// replace existing constraint with new one
layout(view) { view in
    view.left == anotherView.top.left + 50
}
```

Animations
----------

~~Cartography doesn't support animations currently. Because Cartography immediately layout subviews after constraints are installed.~~

Use `constrain()` instead of `layout()` for animations, as @robb mentioned. What we need to do is to call `layoutIfNeeded()` in animation block.

For example:

```swift
// use `constrain()` instead of `layout()`
constrain(view) { view in
    view.left == view.superview!.left + 200
}

// layout in animation block
UIView.animateWithDuration(0.5, animations: {
    view.layoutIfNeeded()
})
```

Or you can pass `view.layoutIfNeeded` to an animation block:

```swift
UIView.animateWithDuration(0.5, animations: view.layoutIfNeeded)
```

I'll make a PR for this as soon as possible.


Related Issues
--------------

- Replace Existing Constraint #26
