### PR TITLE
Support CGFloat

### DIFF
--- a/Cartography.xcodeproj/project.pbxproj
+++ b/Cartography.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		543250CD1A8131F100BE7581 /* TypesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 543250CB1A8112D700BE7581 /* TypesTests.swift */; };
+		543250CE1A8131F200BE7581 /* TypesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 543250CB1A8112D700BE7581 /* TypesTests.swift */; };
 		545F858D195322EA00791F75 /* Edges.swift in Sources */ = {isa = PBXBuildFile; fileRef = 545F858C195322EA00791F75 /* Edges.swift */; };
 		545F858F1953235F00791F75 /* EdgesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 545F858E1953235F00791F75 /* EdgesTests.swift */; };
 		546E9E891950A29300B16707 /* LayoutProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 546E9E881950A29300B16707 /* LayoutProxy.swift */; };
@@ -94,6 +96,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		543250CB1A8112D700BE7581 /* TypesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypesTests.swift; sourceTree = "<group>"; };
 		545F858C195322EA00791F75 /* Edges.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Edges.swift; sourceTree = "<group>"; };
 		545F858E1953235F00791F75 /* EdgesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EdgesTests.swift; sourceTree = "<group>"; };
 		546E9E881950A29300B16707 /* LayoutProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LayoutProxy.swift; sourceTree = "<group>"; };
@@ -231,6 +234,7 @@
 				54B0939A1A716F12008A1102 /* ReplacingConstraintsTests.swift */,
 				54FA3A3D1951A3750094B82A /* PointTests.swift */,
 				54FA3A431951A9730094B82A /* SizeTests.swift */,
+				543250CB1A8112D700BE7581 /* TypesTests.swift */,
 				BB41A06E1A229BF7007142FE /* ViewHierarchyTests.swift */,
 				54C96A21195063CD000CDD27 /* Supporting Files */,
 			);
@@ -451,6 +455,7 @@
 				54FA3A3E1951A3750094B82A /* PointTests.swift in Sources */,
 				545F858F1953235F00791F75 /* EdgesTests.swift in Sources */,
 				54FA3A381950FD8E0094B82A /* OperatorTests.swift in Sources */,
+				543250CD1A8131F100BE7581 /* TypesTests.swift in Sources */,
 				546E9EA21950B33D00B16707 /* DimensionTests.swift in Sources */,
 				BBAC6D191A22A79900E8A3E2 /* ViewUtils.swift in Sources */,
 				546E9E931950A87600B16707 /* EdgeTests.swift in Sources */,
@@ -491,6 +496,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BBAC6D1C1A22A8F400E8A3E2 /* ViewHierarchyTests.swift in Sources */,
+				543250CE1A8131F200BE7581 /* TypesTests.swift in Sources */,
 				BBAC6D1A1A22A8EE00E8A3E2 /* ViewUtils.swift in Sources */,
 				54F6A860195C213F00313D24 /* PointTests.swift in Sources */,
 				54F6A862195C213F00313D24 /* OperatorTests.swift in Sources */,

--- a/Cartography/Coefficients.swift
+++ b/Cartography/Coefficients.swift
@@ -9,53 +9,58 @@
 import Foundation
 
 public struct Coefficients {
-    var multiplier: Float = 1
-    var constant: Float = 0
+    var multiplier: Double = 1
+    var constant: Double = 0
 
     init() { }
 
-    init(_ multiplier: Float, _ constant: Float) {
-        self.multiplier = multiplier
+    init(_ multiplier: Double, _ constant: Double) {
         self.constant = constant
+        self.multiplier = multiplier
+    }
+
+    init(_ multiplier: Number, _ constant: Number) {
+        self.constant = constant.doubleValue
+        self.multiplier = multiplier.doubleValue
     }
 }
 
 // MARK: Addition
 
-public func +(c: Float, rhs: Coefficients) -> Coefficients {
-    return Coefficients(rhs.multiplier, rhs.constant + c)
+public func +(c: Number, rhs: Coefficients) -> Coefficients {
+    return Coefficients(rhs.multiplier, rhs.constant + c.doubleValue)
 }
 
-public func +(lhs: Coefficients, rhs: Float) -> Coefficients {
+public func +(lhs: Coefficients, rhs: Number) -> Coefficients {
     return rhs + lhs
 }
 
 // MARK: Subtraction
 
-public func -(c: Float, rhs: Coefficients) -> Coefficients {
-    return Coefficients(rhs.multiplier, rhs.constant - c)
+public func -(c: Number, rhs: Coefficients) -> Coefficients {
+    return Coefficients(rhs.multiplier, rhs.constant - c.doubleValue)
 }
 
-public func -(lhs: Coefficients, rhs: Float) -> Coefficients {
+public func -(lhs: Coefficients, rhs: Number) -> Coefficients {
     return rhs - lhs
 }
 
 // MARK: Multiplication
 
-public func *(m: Float, rhs: Coefficients) -> Coefficients {
-    return Coefficients(rhs.multiplier * m, rhs.constant * m)
+public func *(m: Number, rhs: Coefficients) -> Coefficients {
+    return Coefficients(rhs.multiplier * m.doubleValue, rhs.constant * m.doubleValue)
 }
 
-public func *(lhs: Coefficients, rhs: Float) -> Coefficients {
+public func *(lhs: Coefficients, rhs: Number) -> Coefficients {
     return rhs * lhs
 }
 
 // MARK: Division
 
-public func /(m: Float, rhs: Coefficients) -> Coefficients {
-    return Coefficients(rhs.multiplier / m, rhs.constant / m)
+public func /(m: Number, rhs: Coefficients) -> Coefficients {
+    return Coefficients(rhs.multiplier / m.doubleValue, rhs.constant / m.doubleValue)
 }
 
-public func /(lhs: Coefficients, rhs: Float) -> Coefficients {
+public func /(lhs: Coefficients, rhs: Number) -> Coefficients {
     return rhs / lhs
 }

--- a/Cartography/Edges.swift
+++ b/Cartography/Edges.swift
@@ -35,16 +35,21 @@ public enum Edges : Compound {
     }
 }
 
-public func inset(edges: Edges, all: Float) -> Expression<Edges> {
+public func inset(edges: Edges, all: Number) -> Expression<Edges> {
     return inset(edges, all, all, all, all)
 }
 
-public func inset(edges: Edges, horizontal: Float, vertical: Float) -> Expression<Edges> {
+public func inset(edges: Edges, horizontal: Number, vertical: Number) -> Expression<Edges> {
     return inset(edges, vertical, horizontal, vertical, horizontal)
 }
 
-public func inset(edges: Edges, top: Float, leading: Float, bottom: Float, trailing: Float) -> Expression<Edges> {
-    return Expression(edges, [ Coefficients(1, top), Coefficients(1, leading), Coefficients(1, -bottom), Coefficients(1, -trailing) ])
+public func inset(edges: Edges, top: Number, leading: Number, bottom: Number, trailing: Number) -> Expression<Edges> {
+    return Expression(edges, [
+        Coefficients(1, top.doubleValue),
+        Coefficients(1, leading.doubleValue),
+        Coefficients(1, -bottom.doubleValue),
+        Coefficients(1, -trailing.doubleValue)
+    ])
 }
 
 // MARK: Equality

--- a/Cartography/Extensions.swift
+++ b/Cartography/Extensions.swift
@@ -17,3 +17,25 @@ internal extension Dictionary {
         }
     }
 }
+
+public protocol Number {
+    var doubleValue: Double { get }
+}
+
+extension Float: Number {
+    public var doubleValue: Double {
+        return Double(self)
+    }
+}
+
+extension Double: Number {
+    public var doubleValue: Double {
+        return self
+    }
+}
+
+extension CGFloat: Number {
+    public var doubleValue: Double {
+        return Double(self)
+    }
+}

--- a/Cartography/Property.swift
+++ b/Cartography/Property.swift
@@ -24,11 +24,11 @@ public protocol Property {
 /// numerical constants.
 public protocol NumericalEquality : Property { }
 
-public func ==(lhs: NumericalEquality, rhs: Float) -> NSLayoutConstraint {
+public func ==(lhs: NumericalEquality, rhs: Number) -> NSLayoutConstraint {
     return lhs.context.addConstraint(lhs, coefficients: Coefficients(1, rhs))
 }
 
-public func ==(lhs: Float, rhs: NumericalEquality) -> NSLayoutConstraint {
+public func ==(lhs: Number, rhs: NumericalEquality) -> NSLayoutConstraint {
     return rhs == lhs
 }
 
@@ -54,19 +54,19 @@ public func ==<P: RelativeEquality>(lhs: P, rhs: P) -> NSLayoutConstraint {
 /// with numerical constants.
 public protocol NumericalInequality : Property { }
 
-public func <=(lhs: NumericalInequality, rhs: Float) -> NSLayoutConstraint {
+public func <=(lhs: NumericalInequality, rhs: Number) -> NSLayoutConstraint {
     return lhs.context.addConstraint(lhs, coefficients: Coefficients(1, rhs), relation: NSLayoutRelation.LessThanOrEqual)
 }
 
-public func <=(lhs: Float, rhs: NumericalInequality) -> NSLayoutConstraint {
+public func <=(lhs: Number, rhs: NumericalInequality) -> NSLayoutConstraint {
     return rhs >= lhs
 }
 
-public func >=(lhs: NumericalInequality, rhs: Float) -> NSLayoutConstraint {
+public func >=(lhs: NumericalInequality, rhs: Number) -> NSLayoutConstraint {
     return lhs.context.addConstraint(lhs, coefficients: Coefficients(1, rhs), relation: NSLayoutRelation.GreaterThanOrEqual)
 }
 
-public func >=(lhs: Float, rhs: NumericalInequality) -> NSLayoutConstraint {
+public func >=(lhs: Number, rhs: NumericalInequality) -> NSLayoutConstraint {
     return rhs <= lhs
 }
 
@@ -102,36 +102,35 @@ public func >=<P: RelativeInequality>(lhs: Expression<P>, rhs: P) -> NSLayoutCon
 
 public protocol Addition : Property { }
 
-public func +<P: Addition>(c: Float, rhs: P) -> Expression<P> {
+public func +<P: Addition>(c: Number, rhs: P) -> Expression<P> {
     return Expression(rhs, [ Coefficients(1, c) ])
 }
 
-public func +<P: Addition>(lhs: P, rhs: Float) -> Expression<P> {
+public func +<P: Addition>(lhs: P, rhs: Number) -> Expression<P> {
     return rhs + lhs
-
 }
 
-public func +<P: Addition>(c: Float, rhs: Expression<P>) -> Expression<P> {
+public func +<P: Addition>(c: Number, rhs: Expression<P>) -> Expression<P> {
     return Expression(rhs.value, rhs.coefficients.map { $0 + c })
 }
 
-public func +<P: Addition>(lhs: Expression<P>, rhs: Float) -> Expression<P> {
+public func +<P: Addition>(lhs: Expression<P>, rhs: Number) -> Expression<P> {
     return rhs + lhs
 }
 
-public func -<P: Addition>(c: Float, rhs: P) -> Expression<P> {
-    return Expression(rhs, [ Coefficients(1, -c) ])
+public func -<P: Addition>(c: Number, rhs: P) -> Expression<P> {
+    return Expression(rhs, [ Coefficients(1, -c.doubleValue) ])
 }
 
-public func -<P: Addition>(lhs: P, rhs: Float) -> Expression<P> {
+public func -<P: Addition>(lhs: P, rhs: Number) -> Expression<P> {
     return rhs - lhs
 }
 
-public func -<P: Addition>(c: Float, rhs: Expression<P>) -> Expression<P> {
+public func -<P: Addition>(c: Number, rhs: Expression<P>) -> Expression<P> {
     return Expression(rhs.value, rhs.coefficients.map { $0 - c})
 }
 
-public func -<P: Addition>(lhs: Expression<P>, rhs: Float) -> Expression<P> {
+public func -<P: Addition>(lhs: Expression<P>, rhs: Number) -> Expression<P> {
     return rhs - lhs
 }
 
@@ -139,34 +138,34 @@ public func -<P: Addition>(lhs: Expression<P>, rhs: Float) -> Expression<P> {
 
 public protocol Multiplication : Property { }
 
-public func *<P: Multiplication>(m: Float, rhs: Expression<P>) -> Expression<P> {
-    return Expression(rhs.value, rhs.coefficients.map { $0 * m })
+public func *<P: Multiplication>(m: Number, rhs: Expression<P>) -> Expression<P> {
+    return Expression(rhs.value, rhs.coefficients.map { $0 * m.doubleValue })
 }
 
-public func *<P: Multiplication>(lhs: Expression<P>, rhs: Float) -> Expression<P> {
+public func *<P: Multiplication>(lhs: Expression<P>, rhs: Number) -> Expression<P> {
     return rhs * lhs
 }
 
-public func *<P: Multiplication>(m: Float, rhs: P) -> Expression<P> {
+public func *<P: Multiplication>(m: Number, rhs: P) -> Expression<P> {
     return Expression(rhs, [ Coefficients(m, 0) ])
 }
 
-public func *<P: Multiplication>(lhs: P, rhs: Float) -> Expression<P> {
+public func *<P: Multiplication>(lhs: P, rhs: Number) -> Expression<P> {
     return rhs * lhs
 }
 
-public func /<P: Multiplication>(m: Float, rhs: Expression<P>) -> Expression<P> {
+public func /<P: Multiplication>(m: Number, rhs: Expression<P>) -> Expression<P> {
     return Expression(rhs.value, rhs.coefficients.map { $0 / m })
 }
 
-public func /<P: Multiplication>(lhs: Expression<P>, rhs: Float) -> Expression<P> {
+public func /<P: Multiplication>(lhs: Expression<P>, rhs: Number) -> Expression<P> {
     return rhs / lhs
 }
 
-public func /<P: Multiplication>(m: Float, rhs: P) -> Expression<P> {
-    return Expression(rhs, [ Coefficients(1 / m, 0) ])
+public func /<P: Multiplication>(m: Number, rhs: P) -> Expression<P> {
+    return Expression(rhs, [ Coefficients(1 / m.doubleValue, 0) ])
 }
 
-public func /<P: Multiplication>(lhs: P, rhs: Float) -> Expression<P> {
+public func /<P: Multiplication>(lhs: P, rhs: Number) -> Expression<P> {
     return rhs / lhs
 }

--- a/Cartography/Size.swift
+++ b/Cartography/Size.swift
@@ -72,36 +72,36 @@ public func >=(lhs: Expression<Size>, rhs: Size) -> [NSLayoutConstraint] {
 
 // MARK: Multiplication
 
-public func *(m: Float, rhs: Expression<Size>) -> Expression<Size> {
-    return Expression(rhs.value, rhs.coefficients.map { $0 * m })
+public func *(m: Number, rhs: Expression<Size>) -> Expression<Size> {
+    return Expression(rhs.value, rhs.coefficients.map { $0 * m.doubleValue })
 }
 
-public func *(lhs: Expression<Size>, rhs: Float) -> Expression<Size> {
+public func *(lhs: Expression<Size>, rhs: Number) -> Expression<Size> {
     return rhs * lhs
 }
 
-public func *(m: Float, rhs: Size) -> Expression<Size> {
-    return Expression(rhs, [ Coefficients(m, 0), Coefficients(m, 0) ])
+public func *(m: Number, rhs: Size) -> Expression<Size> {
+    return Expression(rhs, [ Coefficients(m.doubleValue, 0), Coefficients(m.doubleValue, 0) ])
 }
 
-public func *(lhs: Size, rhs: Float) -> Expression<Size> {
+public func *(lhs: Size, rhs: Number) -> Expression<Size> {
     return rhs * lhs
 }
 
 // MARK: Division
 
-public func /(m: Float, rhs: Expression<Size>) -> Expression<Size> {
-    return Expression(rhs.value, rhs.coefficients.map { $0 / m })
+public func /(m: Number, rhs: Expression<Size>) -> Expression<Size> {
+    return Expression(rhs.value, rhs.coefficients.map { $0 / m.doubleValue })
 }
 
-public func /(lhs: Expression<Size>, rhs: Float) -> Expression<Size> {
+public func /(lhs: Expression<Size>, rhs: Number) -> Expression<Size> {
     return rhs / lhs
 }
 
-public func /(m: Float, rhs: Size) -> Expression<Size> {
-    return Expression(rhs, [ Coefficients(1 / m, 0), Coefficients(1 / m, 0) ])
+public func /(m: Number, rhs: Size) -> Expression<Size> {
+    return Expression(rhs, [ Coefficients(1 / m.doubleValue, 0), Coefficients(1 / m.doubleValue, 0) ])
 }
 
-public func /(lhs: Size, rhs: Float) -> Expression<Size> {
+public func /(lhs: Size, rhs: Number) -> Expression<Size> {
     return rhs / lhs
 }

--- a/CartographyTests/TypesTests.swift
+++ b/CartographyTests/TypesTests.swift
@@ -1,0 +1,58 @@
+//
+//  TypesTests.swift
+//  Cartography
+//
+//  Created by Robert Böhnke on 03/02/15.
+//  Copyright (c) 2015 Robert Böhnke. All rights reserved.
+//
+
+import Cartography
+import XCTest
+
+class TypesTests: XCTestCase {
+    var superview: View!
+    var view: View!
+
+    override func setUp() {
+        superview = View(frame: CGRectMake(0, 0, 400, 400))
+
+        view = View(frame: CGRectZero)
+        superview.addSubview(view)
+    }
+
+    func testFloat() {
+        let width: Float = 200
+        let height: Float = 300
+
+        layout(view) { view in
+            view.width == width
+            view.height == height
+        }
+
+        XCTAssertEqual(view.frame, CGRectMake(0, 0, 200, 300), "It should layout the size")
+    }
+
+    func testDouble() {
+        let width: Double = 200
+        let height: Double = 300
+
+        layout(view) { view in
+            view.width == width
+            view.height == height
+        }
+
+        XCTAssertEqual(view.frame, CGRectMake(0, 0, 200, 300), "It should layout the size")
+    }
+
+    func testCGFloat() {
+        let width: CGFloat = 200
+        let height: CGFloat = 300
+
+        layout(view) { view in
+            view.width == width
+            view.height == height
+        }
+
+        XCTAssertEqual(view.frame, CGRectMake(0, 0, 200, 300), "It should layout the size")
+    }
+}


### PR DESCRIPTION
By adding the `Number` protocol, we can handle `Float`, `Double` and `CGFloat` by simply promoting all of them to `Double`s without defining every operator thrice.

Fixes #56 