### PR TITLE
Add whitespaces between custom operator and generics

### DIFF
--- a/Cartography/Coefficients.swift
+++ b/Cartography/Coefficients.swift
@@ -27,40 +27,40 @@ public struct Coefficients {
 
 // MARK: Addition
 
-public func +(c: Number, rhs: Coefficients) -> Coefficients {
+public func + (c: Number, rhs: Coefficients) -> Coefficients {
     return Coefficients(rhs.multiplier, rhs.constant + c.doubleValue)
 }
 
-public func +(lhs: Coefficients, rhs: Number) -> Coefficients {
+public func + (lhs: Coefficients, rhs: Number) -> Coefficients {
     return rhs + lhs
 }
 
 // MARK: Subtraction
 
-public func -(c: Number, rhs: Coefficients) -> Coefficients {
+public func - (c: Number, rhs: Coefficients) -> Coefficients {
     return Coefficients(rhs.multiplier, rhs.constant - c.doubleValue)
 }
 
-public func -(lhs: Coefficients, rhs: Number) -> Coefficients {
+public func - (lhs: Coefficients, rhs: Number) -> Coefficients {
     return rhs - lhs
 }
 
 // MARK: Multiplication
 
-public func *(m: Number, rhs: Coefficients) -> Coefficients {
+public func * (m: Number, rhs: Coefficients) -> Coefficients {
     return Coefficients(rhs.multiplier * m.doubleValue, rhs.constant * m.doubleValue)
 }
 
-public func *(lhs: Coefficients, rhs: Number) -> Coefficients {
+public func * (lhs: Coefficients, rhs: Number) -> Coefficients {
     return rhs * lhs
 }
 
 // MARK: Division
 
-public func /(m: Number, rhs: Coefficients) -> Coefficients {
+public func / (m: Number, rhs: Coefficients) -> Coefficients {
     return Coefficients(rhs.multiplier / m.doubleValue, rhs.constant / m.doubleValue)
 }
 
-public func /(lhs: Coefficients, rhs: Number) -> Coefficients {
+public func / (lhs: Coefficients, rhs: Number) -> Coefficients {
     return rhs / lhs
 }

--- a/Cartography/Edges.swift
+++ b/Cartography/Edges.swift
@@ -54,40 +54,40 @@ public func inset(edges: Edges, top: Number, leading: Number, bottom: Number, tr
 
 // MARK: Equality
 
-public func ==(lhs: Edges, rhs: Expression<Edges>) -> [NSLayoutConstraint] {
+public func == (lhs: Edges, rhs: Expression<Edges>) -> [NSLayoutConstraint] {
     return lhs.context.addConstraint(lhs, coefficients: rhs.coefficients, to: rhs.value)
 }
 
-public func ==(lhs: Expression<Edges>, rhs: Edges) -> [NSLayoutConstraint] {
+public func == (lhs: Expression<Edges>, rhs: Edges) -> [NSLayoutConstraint] {
     return rhs == lhs
 }
 
-public func ==(lhs: Edges, rhs: Edges) -> [NSLayoutConstraint] {
+public func == (lhs: Edges, rhs: Edges) -> [NSLayoutConstraint] {
     return lhs.context.addConstraint(lhs, to: rhs)
 }
 
 // MARK: Inequality
 
-public func <=(lhs: Edges, rhs: Edges) -> [NSLayoutConstraint] {
+public func <= (lhs: Edges, rhs: Edges) -> [NSLayoutConstraint] {
     return lhs.context.addConstraint(lhs, to: rhs, relation: NSLayoutRelation.LessThanOrEqual)
 }
 
-public func >=(lhs: Edges, rhs: Edges) -> [NSLayoutConstraint] {
+public func >= (lhs: Edges, rhs: Edges) -> [NSLayoutConstraint] {
     return lhs.context.addConstraint(lhs, to: rhs, relation: NSLayoutRelation.GreaterThanOrEqual)
 }
 
-public func <=(lhs: Edges, rhs: Expression<Edges>) -> [NSLayoutConstraint] {
+public func <= (lhs: Edges, rhs: Expression<Edges>) -> [NSLayoutConstraint] {
     return lhs.context.addConstraint(lhs, coefficients: rhs.coefficients, to: rhs.value, relation: NSLayoutRelation.LessThanOrEqual)
 }
 
-public func <=(lhs: Expression<Edges>, rhs: Edges) -> [NSLayoutConstraint] {
+public func <= (lhs: Expression<Edges>, rhs: Edges) -> [NSLayoutConstraint] {
     return rhs >= lhs
 }
 
-public func >=(lhs: Edges, rhs: Expression<Edges>) -> [NSLayoutConstraint] {
+public func >= (lhs: Edges, rhs: Expression<Edges>) -> [NSLayoutConstraint] {
     return lhs.context.addConstraint(lhs, coefficients: rhs.coefficients, to: rhs.value, relation: NSLayoutRelation.GreaterThanOrEqual)
 }
 
-public func >=(lhs: Expression<Edges>, rhs: Edges) -> [NSLayoutConstraint] {
+public func >= (lhs: Expression<Edges>, rhs: Edges) -> [NSLayoutConstraint] {
     return rhs <= lhs
 }

--- a/Cartography/Extensions.swift
+++ b/Cartography/Extensions.swift
@@ -13,7 +13,7 @@
 #endif
 
 internal extension Dictionary {
-    init (_ pairs: [Element]) {
+    init(_ pairs: [Element]) {
         self.init()
 
         for (key, value) in pairs {

--- a/Cartography/Point.swift
+++ b/Cartography/Point.swift
@@ -12,7 +12,7 @@ import UIKit
 import AppKit
 #endif
 
-public enum Point : Compound {
+public enum Point: Compound {
     case Center(Context, View)
 
     var context: Context {
@@ -32,40 +32,40 @@ public enum Point : Compound {
 
 // MARK: Equality
 
-public func ==(lhs: Point, rhs: Expression<Point>) -> [NSLayoutConstraint] {
+public func == (lhs: Point, rhs: Expression<Point>) -> [NSLayoutConstraint] {
     return lhs.context.addConstraint(lhs, coefficients: rhs.coefficients, to: rhs.value)
 }
 
-public func ==(lhs: Expression<Point>, rhs: Point) -> [NSLayoutConstraint] {
+public func == (lhs: Expression<Point>, rhs: Point) -> [NSLayoutConstraint] {
     return rhs == lhs
 }
 
-public func ==(lhs: Point, rhs: Point) -> [NSLayoutConstraint] {
+public func == (lhs: Point, rhs: Point) -> [NSLayoutConstraint] {
     return lhs.context.addConstraint(lhs, to: rhs)
 }
 
 // MARK: Inequality
 
-public func <=(lhs: Point, rhs: Point) -> [NSLayoutConstraint] {
+public func <= (lhs: Point, rhs: Point) -> [NSLayoutConstraint] {
     return lhs.context.addConstraint(lhs, to: rhs, relation: NSLayoutRelation.LessThanOrEqual)
 }
 
-public func >=(lhs: Point, rhs: Point) -> [NSLayoutConstraint] {
+public func >= (lhs: Point, rhs: Point) -> [NSLayoutConstraint] {
     return lhs.context.addConstraint(lhs, to: rhs, relation: NSLayoutRelation.GreaterThanOrEqual)
 }
 
-public func <=(lhs: Point, rhs: Expression<Point>) -> [NSLayoutConstraint] {
+public func <= (lhs: Point, rhs: Expression<Point>) -> [NSLayoutConstraint] {
     return lhs.context.addConstraint(lhs, coefficients: rhs.coefficients, to: rhs.value, relation: NSLayoutRelation.LessThanOrEqual)
 }
 
-public func <=(lhs: Expression<Point>, rhs: Point) -> [NSLayoutConstraint] {
+public func <= (lhs: Expression<Point>, rhs: Point) -> [NSLayoutConstraint] {
     return rhs >= lhs
 }
 
-public func >=(lhs: Point, rhs: Expression<Point>) -> [NSLayoutConstraint] {
+public func >= (lhs: Point, rhs: Expression<Point>) -> [NSLayoutConstraint] {
     return lhs.context.addConstraint(lhs, coefficients: rhs.coefficients, to: rhs.value, relation: NSLayoutRelation.GreaterThanOrEqual)
 }
 
-public func >=(lhs: Expression<Point>, rhs: Point) -> [NSLayoutConstraint] {
+public func >= (lhs: Expression<Point>, rhs: Point) -> [NSLayoutConstraint] {
     return rhs <= lhs
 }

--- a/Cartography/Priority.swift
+++ b/Cartography/Priority.swift
@@ -14,13 +14,13 @@ import AppKit
 
 infix operator  ~ { }
 
-public func ~(lhs: NSLayoutConstraint, rhs: Float) -> NSLayoutConstraint {
+public func ~ (lhs: NSLayoutConstraint, rhs: Float) -> NSLayoutConstraint {
     lhs.priority = rhs
 
     return lhs
 }
 
-public func ~(lhs: [NSLayoutConstraint], rhs: Float) -> [NSLayoutConstraint] {
+public func ~ (lhs: [NSLayoutConstraint], rhs: Float) -> [NSLayoutConstraint] {
     return lhs.map {
         $0 ~ rhs
     }

--- a/Cartography/Property.swift
+++ b/Cartography/Property.swift
@@ -24,11 +24,11 @@ public protocol Property {
 /// numerical constants.
 public protocol NumericalEquality : Property { }
 
-public func ==(lhs: NumericalEquality, rhs: Number) -> NSLayoutConstraint {
+public func == (lhs: NumericalEquality, rhs: Number) -> NSLayoutConstraint {
     return lhs.context.addConstraint(lhs, coefficients: Coefficients(1, rhs))
 }
 
-public func ==(lhs: Number, rhs: NumericalEquality) -> NSLayoutConstraint {
+public func == (lhs: Number, rhs: NumericalEquality) -> NSLayoutConstraint {
     return rhs == lhs
 }
 
@@ -36,15 +36,15 @@ public func ==(lhs: Number, rhs: NumericalEquality) -> NSLayoutConstraint {
 /// properties of the same type.
 public protocol RelativeEquality : Property { }
 
-public func ==<P: RelativeEquality>(lhs: P, rhs: Expression<P>) -> NSLayoutConstraint {
+public func == <P: RelativeEquality>(lhs: P, rhs: Expression<P>) -> NSLayoutConstraint {
     return lhs.context.addConstraint(lhs, coefficients: rhs.coefficients[0], to: rhs.value)
 }
 
-public func ==<P: RelativeEquality>(lhs: Expression<P>, rhs: P) -> NSLayoutConstraint {
+public func == <P: RelativeEquality>(lhs: Expression<P>, rhs: P) -> NSLayoutConstraint {
     return rhs == lhs
 }
 
-public func ==<P: RelativeEquality>(lhs: P, rhs: P) -> NSLayoutConstraint {
+public func == <P: RelativeEquality>(lhs: P, rhs: P) -> NSLayoutConstraint {
     return lhs.context.addConstraint(lhs, to: rhs)
 }
 
@@ -54,19 +54,19 @@ public func ==<P: RelativeEquality>(lhs: P, rhs: P) -> NSLayoutConstraint {
 /// with numerical constants.
 public protocol NumericalInequality : Property { }
 
-public func <=(lhs: NumericalInequality, rhs: Number) -> NSLayoutConstraint {
+public func <= (lhs: NumericalInequality, rhs: Number) -> NSLayoutConstraint {
     return lhs.context.addConstraint(lhs, coefficients: Coefficients(1, rhs), relation: NSLayoutRelation.LessThanOrEqual)
 }
 
-public func <=(lhs: Number, rhs: NumericalInequality) -> NSLayoutConstraint {
+public func <= (lhs: Number, rhs: NumericalInequality) -> NSLayoutConstraint {
     return rhs >= lhs
 }
 
-public func >=(lhs: NumericalInequality, rhs: Number) -> NSLayoutConstraint {
+public func >= (lhs: NumericalInequality, rhs: Number) -> NSLayoutConstraint {
     return lhs.context.addConstraint(lhs, coefficients: Coefficients(1, rhs), relation: NSLayoutRelation.GreaterThanOrEqual)
 }
 
-public func >=(lhs: Number, rhs: NumericalInequality) -> NSLayoutConstraint {
+public func >= (lhs: Number, rhs: NumericalInequality) -> NSLayoutConstraint {
     return rhs <= lhs
 }
 
@@ -74,27 +74,27 @@ public func >=(lhs: Number, rhs: NumericalInequality) -> NSLayoutConstraint {
 /// with other properties of the same type.
 public protocol RelativeInequality : Property { }
 
-public func <=<P: RelativeInequality>(lhs: P, rhs: P) -> NSLayoutConstraint {
+public func <= <P: RelativeInequality>(lhs: P, rhs: P) -> NSLayoutConstraint {
     return lhs.context.addConstraint(lhs, to: rhs, relation: NSLayoutRelation.LessThanOrEqual)
 }
 
-public func >=<P: RelativeInequality>(lhs: P, rhs: P) -> NSLayoutConstraint {
+public func >= <P: RelativeInequality>(lhs: P, rhs: P) -> NSLayoutConstraint {
     return lhs.context.addConstraint(lhs, to: rhs, relation: NSLayoutRelation.GreaterThanOrEqual)
 }
 
-public func <=<P: RelativeInequality>(lhs: P, rhs: Expression<P>) -> NSLayoutConstraint {
+public func <= <P: RelativeInequality>(lhs: P, rhs: Expression<P>) -> NSLayoutConstraint {
     return lhs.context.addConstraint(lhs, coefficients: rhs.coefficients[0], to: rhs.value, relation: NSLayoutRelation.LessThanOrEqual)
 }
 
-public func <=<P: RelativeInequality>(lhs: Expression<P>, rhs: P) -> NSLayoutConstraint {
+public func <= <P: RelativeInequality>(lhs: Expression<P>, rhs: P) -> NSLayoutConstraint {
     return rhs >= lhs
 }
 
-public func >=<P: RelativeInequality>(lhs: P, rhs: Expression<P>) -> NSLayoutConstraint {
+public func >= <P: RelativeInequality>(lhs: P, rhs: Expression<P>) -> NSLayoutConstraint {
     return lhs.context.addConstraint(lhs, coefficients: rhs.coefficients[0], to: rhs.value, relation: NSLayoutRelation.GreaterThanOrEqual)
 }
 
-public func >=<P: RelativeInequality>(lhs: Expression<P>, rhs: P) -> NSLayoutConstraint {
+public func >= <P: RelativeInequality>(lhs: Expression<P>, rhs: P) -> NSLayoutConstraint {
     return rhs <= lhs
 }
 
@@ -102,35 +102,35 @@ public func >=<P: RelativeInequality>(lhs: Expression<P>, rhs: P) -> NSLayoutCon
 
 public protocol Addition : Property { }
 
-public func +<P: Addition>(c: Number, rhs: P) -> Expression<P> {
+public func + <P: Addition>(c: Number, rhs: P) -> Expression<P> {
     return Expression(rhs, [ Coefficients(1, c) ])
 }
 
-public func +<P: Addition>(lhs: P, rhs: Number) -> Expression<P> {
+public func + <P: Addition>(lhs: P, rhs: Number) -> Expression<P> {
     return rhs + lhs
 }
 
-public func +<P: Addition>(c: Number, rhs: Expression<P>) -> Expression<P> {
+public func + <P: Addition>(c: Number, rhs: Expression<P>) -> Expression<P> {
     return Expression(rhs.value, rhs.coefficients.map { $0 + c })
 }
 
-public func +<P: Addition>(lhs: Expression<P>, rhs: Number) -> Expression<P> {
+public func + <P: Addition>(lhs: Expression<P>, rhs: Number) -> Expression<P> {
     return rhs + lhs
 }
 
-public func -<P: Addition>(c: Number, rhs: P) -> Expression<P> {
+public func - <P: Addition>(c: Number, rhs: P) -> Expression<P> {
     return Expression(rhs, [ Coefficients(1, -c.doubleValue) ])
 }
 
-public func -<P: Addition>(lhs: P, rhs: Number) -> Expression<P> {
+public func - <P: Addition>(lhs: P, rhs: Number) -> Expression<P> {
     return rhs - lhs
 }
 
-public func -<P: Addition>(c: Number, rhs: Expression<P>) -> Expression<P> {
+public func - <P: Addition>(c: Number, rhs: Expression<P>) -> Expression<P> {
     return Expression(rhs.value, rhs.coefficients.map { $0 - c})
 }
 
-public func -<P: Addition>(lhs: Expression<P>, rhs: Number) -> Expression<P> {
+public func - <P: Addition>(lhs: Expression<P>, rhs: Number) -> Expression<P> {
     return rhs - lhs
 }
 
@@ -138,34 +138,34 @@ public func -<P: Addition>(lhs: Expression<P>, rhs: Number) -> Expression<P> {
 
 public protocol Multiplication : Property { }
 
-public func *<P: Multiplication>(m: Number, rhs: Expression<P>) -> Expression<P> {
+public func * <P: Multiplication>(m: Number, rhs: Expression<P>) -> Expression<P> {
     return Expression(rhs.value, rhs.coefficients.map { $0 * m.doubleValue })
 }
 
-public func *<P: Multiplication>(lhs: Expression<P>, rhs: Number) -> Expression<P> {
+public func * <P: Multiplication>(lhs: Expression<P>, rhs: Number) -> Expression<P> {
     return rhs * lhs
 }
 
-public func *<P: Multiplication>(m: Number, rhs: P) -> Expression<P> {
+public func * <P: Multiplication>(m: Number, rhs: P) -> Expression<P> {
     return Expression(rhs, [ Coefficients(m, 0) ])
 }
 
-public func *<P: Multiplication>(lhs: P, rhs: Number) -> Expression<P> {
+public func * <P: Multiplication>(lhs: P, rhs: Number) -> Expression<P> {
     return rhs * lhs
 }
 
-public func /<P: Multiplication>(m: Number, rhs: Expression<P>) -> Expression<P> {
+public func / <P: Multiplication>(m: Number, rhs: Expression<P>) -> Expression<P> {
     return Expression(rhs.value, rhs.coefficients.map { $0 / m })
 }
 
-public func /<P: Multiplication>(lhs: Expression<P>, rhs: Number) -> Expression<P> {
+public func / <P: Multiplication>(lhs: Expression<P>, rhs: Number) -> Expression<P> {
     return rhs / lhs
 }
 
-public func /<P: Multiplication>(m: Number, rhs: P) -> Expression<P> {
+public func / <P: Multiplication>(m: Number, rhs: P) -> Expression<P> {
     return Expression(rhs, [ Coefficients(1 / m.doubleValue, 0) ])
 }
 
-public func /<P: Multiplication>(lhs: P, rhs: Number) -> Expression<P> {
+public func / <P: Multiplication>(lhs: P, rhs: Number) -> Expression<P> {
     return rhs / lhs
 }

--- a/Cartography/Size.swift
+++ b/Cartography/Size.swift
@@ -32,76 +32,76 @@ public enum Size : Compound {
 
 // MARK: Equality
 
-public func ==(lhs: Size, rhs: Expression<Size>) -> [NSLayoutConstraint] {
+public func == (lhs: Size, rhs: Expression<Size>) -> [NSLayoutConstraint] {
     return lhs.context.addConstraint(lhs, coefficients: rhs.coefficients, to: rhs.value)
 }
 
-public func ==(lhs: Expression<Size>, rhs: Size) -> [NSLayoutConstraint] {
+public func == (lhs: Expression<Size>, rhs: Size) -> [NSLayoutConstraint] {
     return rhs == lhs
 }
 
-public func ==(lhs: Size, rhs: Size) -> [NSLayoutConstraint] {
+public func == (lhs: Size, rhs: Size) -> [NSLayoutConstraint] {
     return lhs.context.addConstraint(lhs, to: rhs)
 }
 
 // MARK: Inequality
 
-public func <=(lhs: Size, rhs: Size) -> [NSLayoutConstraint] {
+public func <= (lhs: Size, rhs: Size) -> [NSLayoutConstraint] {
     return lhs.context.addConstraint(lhs, to: rhs, relation: NSLayoutRelation.LessThanOrEqual)
 }
 
-public func >=(lhs: Size, rhs: Size) -> [NSLayoutConstraint] {
+public func >= (lhs: Size, rhs: Size) -> [NSLayoutConstraint] {
     return lhs.context.addConstraint(lhs, to: rhs, relation: NSLayoutRelation.GreaterThanOrEqual)
 }
 
-public func <=(lhs: Size, rhs: Expression<Size>) -> [NSLayoutConstraint] {
+public func <= (lhs: Size, rhs: Expression<Size>) -> [NSLayoutConstraint] {
     return lhs.context.addConstraint(lhs, coefficients: rhs.coefficients, to: rhs.value, relation: NSLayoutRelation.LessThanOrEqual)
 }
 
-public func <=(lhs: Expression<Size>, rhs: Size) -> [NSLayoutConstraint] {
+public func <= (lhs: Expression<Size>, rhs: Size) -> [NSLayoutConstraint] {
     return rhs >= lhs
 }
 
-public func >=(lhs: Size, rhs: Expression<Size>) -> [NSLayoutConstraint] {
+public func >= (lhs: Size, rhs: Expression<Size>) -> [NSLayoutConstraint] {
     return lhs.context.addConstraint(lhs, coefficients: rhs.coefficients, to: rhs.value, relation: NSLayoutRelation.GreaterThanOrEqual)
 }
 
-public func >=(lhs: Expression<Size>, rhs: Size) -> [NSLayoutConstraint] {
+public func >= (lhs: Expression<Size>, rhs: Size) -> [NSLayoutConstraint] {
     return rhs <= lhs
 }
 
 // MARK: Multiplication
 
-public func *(m: Number, rhs: Expression<Size>) -> Expression<Size> {
+public func * (m: Number, rhs: Expression<Size>) -> Expression<Size> {
     return Expression(rhs.value, rhs.coefficients.map { $0 * m.doubleValue })
 }
 
-public func *(lhs: Expression<Size>, rhs: Number) -> Expression<Size> {
+public func * (lhs: Expression<Size>, rhs: Number) -> Expression<Size> {
     return rhs * lhs
 }
 
-public func *(m: Number, rhs: Size) -> Expression<Size> {
+public func * (m: Number, rhs: Size) -> Expression<Size> {
     return Expression(rhs, [ Coefficients(m.doubleValue, 0), Coefficients(m.doubleValue, 0) ])
 }
 
-public func *(lhs: Size, rhs: Number) -> Expression<Size> {
+public func * (lhs: Size, rhs: Number) -> Expression<Size> {
     return rhs * lhs
 }
 
 // MARK: Division
 
-public func /(m: Number, rhs: Expression<Size>) -> Expression<Size> {
+public func / (m: Number, rhs: Expression<Size>) -> Expression<Size> {
     return Expression(rhs.value, rhs.coefficients.map { $0 / m.doubleValue })
 }
 
-public func /(lhs: Expression<Size>, rhs: Number) -> Expression<Size> {
+public func / (lhs: Expression<Size>, rhs: Number) -> Expression<Size> {
     return rhs / lhs
 }
 
-public func /(m: Number, rhs: Size) -> Expression<Size> {
+public func / (m: Number, rhs: Size) -> Expression<Size> {
     return Expression(rhs, [ Coefficients(1 / m.doubleValue, 0), Coefficients(1 / m.doubleValue, 0) ])
 }
 
-public func /(lhs: Size, rhs: Number) -> Expression<Size> {
+public func / (lhs: Size, rhs: Number) -> Expression<Size> {
     return rhs / lhs
 }

--- a/Cartography/ViewUtils.swift
+++ b/Cartography/ViewUtils.swift
@@ -24,7 +24,7 @@ func closestCommonAncestor(a: View, b: View?) -> View? {
         if a == bSuper { return a }
         if b == aSuper { return b }
         if aSuper == bSuper { return aSuper }
-        
+
         // None of those; run the general algorithm
         var ancestorsOfA = NSSet(array: Array(ancestors(a)))
         for ancestor in ancestors(b) {


### PR DESCRIPTION
I'm really impressed by this repository. Thank you.

When I read code of this repository, I noticed one thing...

Code like below is a little bit not readable
the operator is <=? or <=< ? 

```
public func <=<P: RelativeInequality>(lhs: P, rhs: P) -> NSLayoutConstraint {
```

So I added a whitespace after the operator.

If you would like, please merge this...

Sorry for sending such a simple and ridiculous change.

Thank you.