### PR TITLE
Add align methods to align multiple views

### DIFF
--- a/Cartography.xcodeproj/project.pbxproj
+++ b/Cartography.xcodeproj/project.pbxproj
@@ -29,6 +29,10 @@
 		54B093991A716A2E008A1102 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54B093961A7165F2008A1102 /* Extensions.swift */; };
 		54B0939C1A7172E4008A1102 /* ReplacingConstraintsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54B0939A1A716F12008A1102 /* ReplacingConstraintsTests.swift */; };
 		54B0939D1A7172E4008A1102 /* ReplacingConstraintsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54B0939A1A716F12008A1102 /* ReplacingConstraintsTests.swift */; };
+		54BF29B01A9348B30066ED10 /* Align.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54BF29AF1A9348B30066ED10 /* Align.swift */; };
+		54BF29B31A934F240066ED10 /* AlignTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54BF29B11A934ECF0066ED10 /* AlignTests.swift */; };
+		54BF29B41A934F250066ED10 /* AlignTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54BF29B11A934ECF0066ED10 /* AlignTests.swift */; };
+		54BF29B51A9350170066ED10 /* Align.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54BF29AF1A9348B30066ED10 /* Align.swift */; };
 		54C96A17195063CD000CDD27 /* Cartography.h in Headers */ = {isa = PBXBuildFile; fileRef = 54C96A16195063CD000CDD27 /* Cartography.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		54C96A1D195063CD000CDD27 /* Cartography.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 54C96A11195063CD000CDD27 /* Cartography.framework */; };
 		54C96A30195064A6000CDD27 /* Property.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54C96A2F195064A6000CDD27 /* Property.swift */; };
@@ -111,6 +115,8 @@
 		54B093941A715E52008A1102 /* ConstraintGroup.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConstraintGroup.swift; sourceTree = "<group>"; };
 		54B093961A7165F2008A1102 /* Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		54B0939A1A716F12008A1102 /* ReplacingConstraintsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReplacingConstraintsTests.swift; sourceTree = "<group>"; };
+		54BF29AF1A9348B30066ED10 /* Align.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Align.swift; sourceTree = "<group>"; };
+		54BF29B11A934ECF0066ED10 /* AlignTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlignTests.swift; sourceTree = "<group>"; };
 		54C96A11195063CD000CDD27 /* Cartography.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Cartography.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		54C96A15195063CD000CDD27 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		54C96A16195063CD000CDD27 /* Cartography.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Cartography.h; sourceTree = "<group>"; };
@@ -192,6 +198,7 @@
 			isa = PBXGroup;
 			children = (
 				54C96A16195063CD000CDD27 /* Cartography.h */,
+				54BF29AF1A9348B30066ED10 /* Align.swift */,
 				546E9E8E1950A33700B16707 /* Coefficients.swift */,
 				54FA3A3F1951A41B0094B82A /* Compound.swift */,
 				547BC85619E2EB9B007BEE9E /* Constraint.swift */,
@@ -226,6 +233,7 @@
 		54C96A20195063CD000CDD27 /* CartographyTests */ = {
 			isa = PBXGroup;
 			children = (
+				54BF29B11A934ECF0066ED10 /* AlignTests.swift */,
 				54A388981A7663AC003945B7 /* ConstraintGroupTests.swift */,
 				54C96A23195063CD000CDD27 /* DimensionTests.swift */,
 				545F858E1953235F00791F75 /* EdgesTests.swift */,
@@ -443,6 +451,7 @@
 				546E9E8F1950A33700B16707 /* Coefficients.swift in Sources */,
 				54FA3A401951A41B0094B82A /* Compound.swift in Sources */,
 				54B093951A715E52008A1102 /* ConstraintGroup.swift in Sources */,
+				54BF29B01A9348B30066ED10 /* Align.swift in Sources */,
 				546E9E951950A97F00B16707 /* Expression.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -452,6 +461,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				54FA3A441951A9730094B82A /* SizeTests.swift in Sources */,
+				54BF29B31A934F240066ED10 /* AlignTests.swift in Sources */,
 				54FA3A3E1951A3750094B82A /* PointTests.swift in Sources */,
 				545F858F1953235F00791F75 /* EdgesTests.swift in Sources */,
 				54FA3A381950FD8E0094B82A /* OperatorTests.swift in Sources */,
@@ -474,6 +484,7 @@
 				549B47B71A581992002498C7 /* Constraint.swift in Sources */,
 				54F6A856195C213A00313D24 /* Edges.swift in Sources */,
 				54F6A858195C213A00313D24 /* LayoutProxy.swift in Sources */,
+				54BF29B51A9350170066ED10 /* Align.swift in Sources */,
 				54F6A853195C213A00313D24 /* Compound.swift in Sources */,
 				54B093991A716A2E008A1102 /* Extensions.swift in Sources */,
 				54F6A859195C213A00313D24 /* Priority.swift in Sources */,
@@ -495,6 +506,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BBAC6D1C1A22A8F400E8A3E2 /* ViewHierarchyTests.swift in Sources */,
+				54BF29B41A934F250066ED10 /* AlignTests.swift in Sources */,
 				543250CE1A8131F200BE7581 /* TypesTests.swift in Sources */,
 				BBAC6D1A1A22A8EE00E8A3E2 /* ViewUtils.swift in Sources */,
 				54F6A860195C213F00313D24 /* PointTests.swift in Sources */,

--- a/Cartography/Align.swift
+++ b/Cartography/Align.swift
@@ -12,17 +12,10 @@ import UIKit
 import AppKit
 #endif
 
-private typealias Accumulator = (previous: LayoutProxy, constraints: [NSLayoutConstraint])
-
 private func makeEqual<P: RelativeEquality>(attribute: LayoutProxy -> P, first: LayoutProxy, rest: [LayoutProxy]) -> [NSLayoutConstraint] {
-    let result = reduce(rest, (first, [])) { (var acc: Accumulator, current) in
-        acc.constraints += [ attribute(current) == attribute(acc.previous) ]
-        acc.previous = current
-
-        return acc
+    return reduce(rest, []) { acc, current in
+        return acc + [ attribute(first) == attribute(current) ]
     }
-
-    return result.1
 }
 
 public func align(top first: LayoutProxy, rest: LayoutProxy...) -> [NSLayoutConstraint] {

--- a/Cartography/Align.swift
+++ b/Cartography/Align.swift
@@ -1,0 +1,54 @@
+//
+//  Align.swift
+//  Cartography
+//
+//  Created by Robert Böhnke on 17/02/15.
+//  Copyright (c) 2015 Robert Böhnke. All rights reserved.
+//
+
+#if os(iOS)
+import UIKit
+#else
+import AppKit
+#endif
+
+private typealias Accumulator = (previous: LayoutProxy, constraints: [NSLayoutConstraint])
+
+private func makeEqual<P: RelativeEquality>(attribute: LayoutProxy -> P, first: LayoutProxy, rest: [LayoutProxy]) -> [NSLayoutConstraint] {
+    let result = reduce(rest, (first, [])) { (var acc: Accumulator, current) in
+        acc.constraints += [ attribute(current) == attribute(acc.previous) ]
+        acc.previous = current
+
+        return acc
+    }
+
+    return result.1
+}
+
+public func align(top first: LayoutProxy, rest: LayoutProxy...) -> [NSLayoutConstraint] {
+    return makeEqual({ $0.top }, first, rest)
+}
+
+public func align(right first: LayoutProxy, rest: LayoutProxy...) -> [NSLayoutConstraint] {
+    return makeEqual({ $0.right }, first, rest)
+}
+
+public func align(bottom first: LayoutProxy, rest: LayoutProxy...) -> [NSLayoutConstraint] {
+    return makeEqual({ $0.bottom }, first, rest)
+}
+
+public func align(left first: LayoutProxy, rest: LayoutProxy...) -> [NSLayoutConstraint] {
+    return makeEqual({ $0.left }, first, rest)
+}
+
+public func align(leading first: LayoutProxy, rest: LayoutProxy...) -> [NSLayoutConstraint] {
+    return makeEqual({ $0.leading }, first, rest)
+}
+
+public func align(trailing first: LayoutProxy, rest: LayoutProxy...) -> [NSLayoutConstraint] {
+    return makeEqual({ $0.trailing }, first, rest)
+}
+
+public func align(baseline first: LayoutProxy, rest: LayoutProxy...) -> [NSLayoutConstraint] {
+    return makeEqual({ $0.baseline }, first, rest)
+}

--- a/Cartography/Align.swift
+++ b/Cartography/Align.swift
@@ -49,6 +49,14 @@ public func align(trailing first: LayoutProxy, rest: LayoutProxy...) -> [NSLayou
     return makeEqual({ $0.trailing }, first, rest)
 }
 
+public func align(centerX first: LayoutProxy, rest: LayoutProxy...) -> [NSLayoutConstraint] {
+    return makeEqual({ $0.centerX }, first, rest)
+}
+
+public func align(centerY first: LayoutProxy, rest: LayoutProxy...) -> [NSLayoutConstraint] {
+    return makeEqual({ $0.centerY }, first, rest)
+}
+
 public func align(baseline first: LayoutProxy, rest: LayoutProxy...) -> [NSLayoutConstraint] {
     return makeEqual({ $0.baseline }, first, rest)
 }

--- a/CartographyTests/AlignTests.swift
+++ b/CartographyTests/AlignTests.swift
@@ -36,12 +36,25 @@ class AlignTests: XCTestCase {
         }
     }
 
-    func testAlign() {
+    func testAlignEdges() {
         layout(viewA, viewB, viewC) { viewA, viewB, viewC in
             align(top: viewA, viewB, viewC)
             align(right: viewA, viewB, viewC)
             align(bottom: viewA, viewB, viewC)
             align(left: viewA, viewB, viewC)
+        }
+
+        XCTAssertEqual(viewA.frame, viewB.frame, "It should align the edges")
+        XCTAssertEqual(viewA.frame, viewC.frame, "It should align the edges")
+    }
+
+    func testAlignCenter() {
+        layout(viewA, viewB, viewC) { viewA, viewB, viewC in
+            viewA.size == viewB.size
+            viewB.size == viewC.size
+
+            align(centerX: viewA, viewB, viewC)
+            align(centerY: viewA, viewB, viewC)
         }
 
         XCTAssertEqual(viewA.frame, viewB.frame, "It should align the edges")

--- a/CartographyTests/AlignTests.swift
+++ b/CartographyTests/AlignTests.swift
@@ -1,0 +1,50 @@
+//
+//  AlignTests.swift
+//  Cartography
+//
+//  Created by Robert Böhnke on 17/02/15.
+//  Copyright (c) 2015 Robert Böhnke. All rights reserved.
+//
+
+import Cartography
+import XCTest
+
+class AlignTests: XCTestCase {
+    var superview: View!
+    var viewA: View!
+    var viewB: View!
+    var viewC: View!
+
+    override func setUp() {
+        superview = View(frame: CGRectMake(0, 0, 400, 400))
+
+        viewA = View(frame: CGRectZero)
+        superview.addSubview(viewA)
+
+        viewB = View(frame: CGRectZero)
+        superview.addSubview(viewB)
+
+        viewC = View(frame: CGRectZero)
+        superview.addSubview(viewC)
+
+        constrain(viewA) { view in
+            view.height == 200
+            view.width == 200
+
+            view.top  == view.superview!.top  + 10
+            view.left == view.superview!.left + 10
+        }
+    }
+
+    func testAlign() {
+        layout(viewA, viewB, viewC) { viewA, viewB, viewC in
+            align(top: viewA, viewB, viewC)
+            align(right: viewA, viewB, viewC)
+            align(bottom: viewA, viewB, viewC)
+            align(left: viewA, viewB, viewC)
+        }
+
+        XCTAssertEqual(viewA.frame, viewB.frame, "It should align the edges")
+        XCTAssertEqual(viewA.frame, viewC.frame, "It should align the edges")
+    }
+}

--- a/README.md
+++ b/README.md
@@ -114,6 +114,17 @@ layout(view) { view in
 Swift](https://github.com/robb/Cartography/issues/9), this only affects single
 line blocks, however.)
 
+If you need to align multiple views by a common edge, you can use the align
+methods:
+
+```swift
+layout(view1, view2, view3) { view1, view2, view3 in
+    align(top: view1, view2, view3); return
+}
+```
+
+Which is equivalent to `view1.top == view2.top; view2.top == view3.top`.
+
 ## Setting priorities
 
 You can set the priorities of your constraints using the `~` operator:

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ layout(view) { view in
 Swift](https://github.com/robb/Cartography/issues/9), this only affects single
 line blocks, however.)
 
-If you need to align multiple views by a common edge, you can use the align
+If you need to align multiple views by a common edge, you can use the `align`
 methods:
 
 ```swift

--- a/README.md
+++ b/README.md
@@ -123,7 +123,9 @@ layout(view1, view2, view3) { view1, view2, view3 in
 }
 ```
 
-Which is equivalent to `view1.top == view2.top; view2.top == view3.top`.
+Which is equivalent to `view1.top == view2.top; view2.top == view3.top`. Similar
+variants exist for `top`, `right` `bottom`, `left`, `leading`, `trailing`,
+`centerX`, `centerY` and `baseline`.
 
 ## Setting priorities
 


### PR DESCRIPTION
This adds multiple `align` methods that take a list of at least two `LayoutProxy` instances and align them by a given edge.

E.g.:

```swift
constrain(logIn, logOut, selfDestruct) {
    // Equivalent to
    //
    //     logIn.bottom  == logOut.bottom
    //     logOut.bottom == selfDesctruct.bottom
    //
    align(bottom: logIn, logOut, selfDesctruct)
}
```

/cc @mergesort

Fixes #77 