### PR TITLE
Add distribute

### DIFF
--- a/Cartography.xcodeproj/project.pbxproj
+++ b/Cartography.xcodeproj/project.pbxproj
@@ -7,10 +7,14 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		54143E4E1A93991D00208182 /* Distribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5467916E1A93962000DC9BF7 /* Distribute.swift */; };
+		54143E511A939D7000208182 /* DistributeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54143E4F1A939D6000208182 /* DistributeTests.swift */; };
+		54143E521A939D7100208182 /* DistributeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54143E4F1A939D6000208182 /* DistributeTests.swift */; };
 		543250CD1A8131F100BE7581 /* TypesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 543250CB1A8112D700BE7581 /* TypesTests.swift */; };
 		543250CE1A8131F200BE7581 /* TypesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 543250CB1A8112D700BE7581 /* TypesTests.swift */; };
 		545F858D195322EA00791F75 /* Edges.swift in Sources */ = {isa = PBXBuildFile; fileRef = 545F858C195322EA00791F75 /* Edges.swift */; };
 		545F858F1953235F00791F75 /* EdgesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 545F858E1953235F00791F75 /* EdgesTests.swift */; };
+		5467916F1A93962000DC9BF7 /* Distribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5467916E1A93962000DC9BF7 /* Distribute.swift */; };
 		546E9E891950A29300B16707 /* LayoutProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 546E9E881950A29300B16707 /* LayoutProxy.swift */; };
 		546E9E8D1950A31100B16707 /* Dimension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 546E9E8C1950A31100B16707 /* Dimension.swift */; };
 		546E9E8F1950A33700B16707 /* Coefficients.swift in Sources */ = {isa = PBXBuildFile; fileRef = 546E9E8E1950A33700B16707 /* Coefficients.swift */; };
@@ -100,9 +104,11 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		54143E4F1A939D6000208182 /* DistributeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DistributeTests.swift; sourceTree = "<group>"; };
 		543250CB1A8112D700BE7581 /* TypesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypesTests.swift; sourceTree = "<group>"; };
 		545F858C195322EA00791F75 /* Edges.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Edges.swift; sourceTree = "<group>"; };
 		545F858E1953235F00791F75 /* EdgesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EdgesTests.swift; sourceTree = "<group>"; };
+		5467916E1A93962000DC9BF7 /* Distribute.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Distribute.swift; sourceTree = "<group>"; };
 		546E9E881950A29300B16707 /* LayoutProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LayoutProxy.swift; sourceTree = "<group>"; };
 		546E9E8C1950A31100B16707 /* Dimension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Dimension.swift; sourceTree = "<group>"; };
 		546E9E8E1950A33700B16707 /* Coefficients.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Coefficients.swift; sourceTree = "<group>"; };
@@ -205,6 +211,7 @@
 				54B093941A715E52008A1102 /* ConstraintGroup.swift */,
 				547BC85419E2DD06007BEE9E /* Context.swift */,
 				546E9E8C1950A31100B16707 /* Dimension.swift */,
+				5467916E1A93962000DC9BF7 /* Distribute.swift */,
 				546E9E901950A76C00B16707 /* Edge.swift */,
 				545F858C195322EA00791F75 /* Edges.swift */,
 				546E9E941950A97F00B16707 /* Expression.swift */,
@@ -236,6 +243,7 @@
 				54BF29B11A934ECF0066ED10 /* AlignTests.swift */,
 				54A388981A7663AC003945B7 /* ConstraintGroupTests.swift */,
 				54C96A23195063CD000CDD27 /* DimensionTests.swift */,
+				54143E4F1A939D6000208182 /* DistributeTests.swift */,
 				545F858E1953235F00791F75 /* EdgesTests.swift */,
 				546E9E921950A87600B16707 /* EdgeTests.swift */,
 				54FA3A371950FD8E0094B82A /* OperatorTests.swift */,
@@ -444,6 +452,7 @@
 				BBAC6D131A22A27900E8A3E2 /* ViewUtils.swift in Sources */,
 				546E9E8D1950A31100B16707 /* Dimension.swift in Sources */,
 				54DF9F3319DAD8DA00EE3609 /* Layout.swift in Sources */,
+				5467916F1A93962000DC9BF7 /* Distribute.swift in Sources */,
 				546E9E911950A76C00B16707 /* Edge.swift in Sources */,
 				54FA3A421951A8070094B82A /* Size.swift in Sources */,
 				54FA3A3C1951A2B60094B82A /* Point.swift in Sources */,
@@ -462,6 +471,7 @@
 			files = (
 				54FA3A441951A9730094B82A /* SizeTests.swift in Sources */,
 				54BF29B31A934F240066ED10 /* AlignTests.swift in Sources */,
+				54143E511A939D7000208182 /* DistributeTests.swift in Sources */,
 				54FA3A3E1951A3750094B82A /* PointTests.swift in Sources */,
 				545F858F1953235F00791F75 /* EdgesTests.swift in Sources */,
 				54FA3A381950FD8E0094B82A /* OperatorTests.swift in Sources */,
@@ -489,6 +499,7 @@
 				54B093991A716A2E008A1102 /* Extensions.swift in Sources */,
 				54F6A859195C213A00313D24 /* Priority.swift in Sources */,
 				54F6A852195C213A00313D24 /* Coefficients.swift in Sources */,
+				54143E4E1A93991D00208182 /* Distribute.swift in Sources */,
 				54F6A85A195C213A00313D24 /* Point.swift in Sources */,
 				54B093981A716A2A008A1102 /* ConstraintGroup.swift in Sources */,
 				54F6A865195C226700313D24 /* View.swift in Sources */,
@@ -507,6 +518,7 @@
 			files = (
 				BBAC6D1C1A22A8F400E8A3E2 /* ViewHierarchyTests.swift in Sources */,
 				54BF29B41A934F250066ED10 /* AlignTests.swift in Sources */,
+				54143E521A939D7100208182 /* DistributeTests.swift in Sources */,
 				543250CE1A8131F200BE7581 /* TypesTests.swift in Sources */,
 				BBAC6D1A1A22A8EE00E8A3E2 /* ViewUtils.swift in Sources */,
 				54F6A860195C213F00313D24 /* PointTests.swift in Sources */,

--- a/Cartography/Distribute.swift
+++ b/Cartography/Distribute.swift
@@ -1,0 +1,31 @@
+//
+//  Distribute.swift
+//  Cartography
+//
+//  Created by Robert Böhnke on 17/02/15.
+//  Copyright (c) 2015 Robert Böhnke. All rights reserved.
+//
+
+import Foundation
+
+typealias Accumulator = ([NSLayoutConstraint], LayoutProxy)
+
+private func reduce(first: LayoutProxy, rest: [LayoutProxy], combine: (LayoutProxy, LayoutProxy) -> NSLayoutConstraint) -> [NSLayoutConstraint] {
+    return reduce(rest, ([], first)) { (acc, current) -> Accumulator in
+        var (constraints, previous) = acc
+
+        return (constraints + [ combine(previous, current) ], current)
+    }.0
+}
+
+public func distribute(by amount: Double, horizontally first: LayoutProxy, rest: LayoutProxy...) -> [NSLayoutConstraint] {
+    return reduce(first, rest) { $0.trailing + amount == $1.leading }
+}
+
+public func distribute(by amount: Double, leftToRight first: LayoutProxy, rest: LayoutProxy...) -> [NSLayoutConstraint] {
+    return reduce(first, rest) { $0.right + amount == $1.left }
+}
+
+public func distribute(by amount: Double, vertically first: LayoutProxy, rest: LayoutProxy...) -> [NSLayoutConstraint] {
+    return reduce(first, rest) { $0.bottom + amount == $1.top }
+}

--- a/CartographyTests/DistributeTests.swift
+++ b/CartographyTests/DistributeTests.swift
@@ -1,0 +1,75 @@
+//
+//  DistributeTests.swift
+//  Cartography
+//
+//  Created by Robert Böhnke on 17/02/15.
+//  Copyright (c) 2015 Robert Böhnke. All rights reserved.
+//
+
+import Cartography
+import XCTest
+
+class DistributeTests: XCTestCase {
+    var superview: View!
+    var viewA: View!
+    var viewB: View!
+    var viewC: View!
+
+    override func setUp() {
+        superview = View(frame: CGRectMake(0, 0, 400, 400))
+
+        viewA = View(frame: CGRectZero)
+        superview.addSubview(viewA)
+
+        viewB = View(frame: CGRectZero)
+        superview.addSubview(viewB)
+
+        viewC = View(frame: CGRectZero)
+        superview.addSubview(viewC)
+
+        constrain(viewA, viewB, viewC) { viewA, viewB, viewC in
+            viewA.width  == 100
+            viewA.height == 100
+
+            viewA.top  == viewA.superview!.top
+            viewA.left == viewA.superview!.left
+
+            viewB.size == viewA.size
+            viewC.size == viewA.size
+        }
+    }
+
+    func testDistributeHorizontally() {
+        layout(viewA, viewB, viewC) { viewA, viewB, viewC in
+            align(centerY: viewA, viewB, viewC)
+            distribute(by: 10, horizontally: viewA, viewB, viewC)
+        }
+
+        XCTAssertEqual(viewA.frame, CGRect(x:   0, y: 0, width: 100, height: 100), "It should distribute the views")
+        XCTAssertEqual(viewB.frame, CGRect(x: 110, y: 0, width: 100, height: 100), "It should distribute the views")
+        XCTAssertEqual(viewC.frame, CGRect(x: 220, y: 0, width: 100, height: 100), "It should distribute the views")
+    }
+
+    func testDistributeLeftToRight() {
+        layout(viewA, viewB, viewC) { viewA, viewB, viewC in
+            align(centerY: viewA, viewB, viewC)
+            distribute(by: 10, leftToRight: viewA, viewB, viewC)
+        }
+
+        XCTAssertEqual(viewA.frame, CGRect(x:   0, y: 0, width: 100, height: 100), "It should distribute the views")
+        XCTAssertEqual(viewB.frame, CGRect(x: 110, y: 0, width: 100, height: 100), "It should distribute the views")
+        XCTAssertEqual(viewC.frame, CGRect(x: 220, y: 0, width: 100, height: 100), "It should distribute the views")
+    }
+
+    func testDistributeVertically() {
+        layout(viewA, viewB, viewC) { viewA, viewB, viewC in
+            align(centerX: viewA, viewB, viewC)
+            distribute(by: 10, vertically: viewA, viewB, viewC)
+        }
+
+        XCTAssertEqual(viewA.frame, CGRect(x: 0, y:   0, width: 100, height: 100), "It should distribute the views")
+        XCTAssertEqual(viewB.frame, CGRect(x: 0, y: 110, width: 100, height: 100), "It should distribute the views")
+        XCTAssertEqual(viewC.frame, CGRect(x: 0, y: 220, width: 100, height: 100), "It should distribute the views")
+    }
+}
+


### PR DESCRIPTION
Adds `distribute` methods to space out multiple views horizontally, vertically or left-to-right.

E.g.

```swift
constrain(logIn, logOut, selfDestruct) {
    // Equivalent to
    //
    //     logIn.trailing  + 10 == logOut.leading
    //     logOut.trailing + 10 == selfDesctruct.leading
    //
    distribute(by: 10, horizontally: logIn, logOut, selfDesctruct)
}
```

Fixes #85 