### PR TITLE
Ignore UIViews owned by UIViewController

### DIFF
--- a/Cartography/Context.swift
+++ b/Cartography/Context.swift
@@ -16,8 +16,8 @@ public class Context {
     internal var constraints: [Constraint] = []
 
     internal func addConstraint(from: Property, to: Property? = nil, coefficients: Coefficients = Coefficients(), relation: NSLayoutRelation = .Equal) -> NSLayoutConstraint {
-        from.view.car_setTranslatesAutoresizingMaskIntoConstraints(false)
-        to?.view.car_setTranslatesAutoresizingMaskIntoConstraints(false)
+        from.view.car_disableTranslatesAutoresizingMaskIntoConstraintsIfPossible()
+        to?.view.car_disableTranslatesAutoresizingMaskIntoConstraintsIfPossible()
 
         var toAttribute: NSLayoutAttribute! = NSLayoutAttribute.NotAnAttribute
 

--- a/Cartography/View.swift
+++ b/Cartography/View.swift
@@ -17,8 +17,26 @@ import Foundation
             layoutIfNeeded()
         }
 
-        func car_setTranslatesAutoresizingMaskIntoConstraints(flag: Bool) {
-            setTranslatesAutoresizingMaskIntoConstraints(flag)
+        func car_disableTranslatesAutoresizingMaskIntoConstraintsIfPossible() {
+            if car_isOwnedByViewController {
+                setTranslatesAutoresizingMaskIntoConstraints(false)
+            }
+        }
+
+        private var car_isOwnedByViewController: Bool {
+            return self === car_closestViewController?.view
+        }
+
+        private var car_closestViewController: UIViewController? {
+            var responder: UIResponder = self
+
+            while let nextResponder = nextResponder() {
+                responder = nextResponder
+
+                if nextResponder.isKindOfClass(UIViewController.Type) { break }
+            }
+
+            return responder as? UIViewController
         }
     }
 #else
@@ -30,8 +48,8 @@ import Foundation
             (superview ?? self).layoutSubtreeIfNeeded()
         }
 
-        func car_setTranslatesAutoresizingMaskIntoConstraints(flag: Bool) {
-            translatesAutoresizingMaskIntoConstraints = flag
+        func car_disableTranslatesAutoresizingMaskIntoConstraintsIfPossible() {
+            translatesAutoresizingMaskIntoConstraints = false
         }
     }
 #endif

--- a/Cartography/View.swift
+++ b/Cartography/View.swift
@@ -18,7 +18,7 @@ import Foundation
         }
 
         func car_disableTranslatesAutoresizingMaskIntoConstraintsIfPossible() {
-            if car_isOwnedByViewController {
+            if !car_isOwnedByViewController {
                 setTranslatesAutoresizingMaskIntoConstraints(false)
             }
         }
@@ -31,6 +31,8 @@ import Foundation
             var responder: UIResponder = self
 
             while let nextResponder = nextResponder() {
+                if nextResponder === responder { break }
+
                 responder = nextResponder
 
                 if nextResponder.isKindOfClass(UIViewController.Type) { break }


### PR DESCRIPTION
This stops Cartography from calling `setTranslatesAutoresizingMaskIntoConstraints(false)` on `UIView`s that are owned by `UIViewController`, since they may depend on their autoresizing mask-based constraints.

Fixes #87 