### PR TITLE
Refactor properties

### DIFF
--- a/Cartography/Compound.swift
+++ b/Cartography/Compound.swift
@@ -12,7 +12,85 @@ import UIKit
 import AppKit
 #endif
 
-protocol Compound {
+public protocol Compound {
     var context: Context { get }
     var properties: [Property] { get }
+}
+
+/// Compound properties conforming to this protocol can use the `==` operator
+/// with other compound properties of the same type.
+public protocol RelativeCompoundEquality : Compound { }
+
+/// Declares a property equal to a the result of an expression.
+///
+/// :param: lhs The affected property. The associated view will have
+///             `translatesAutoresizingMaskIntoConstraints` set to `false`.
+/// :param: rhs The expression.
+///
+/// :returns: An `NSLayoutConstraint`.
+///
+public func == <P: RelativeCompoundEquality>(lhs: P, rhs: Expression<P>) -> [NSLayoutConstraint] {
+    return lhs.context.addConstraint(lhs, coefficients: rhs.coefficients, to: rhs.value)
+}
+
+/// Declares a property equal to another compound property.
+///
+/// :param: lhs The affected property. The associated view will have
+///             `translatesAutoresizingMaskIntoConstraints` set to `false`.
+/// :param: rhs The other property.
+///
+public func == <P: RelativeCompoundEquality>(lhs: P, rhs: P) -> [NSLayoutConstraint] {
+    return lhs.context.addConstraint(lhs, to: rhs)
+}
+
+/// Compound properties conforming to this protocol can use the `<=` and `>=`
+/// operators with other compound properties of the same type.
+public protocol RelativeCompoundInequality : Compound { }
+
+/// Declares a property less than or equal to another compound property.
+///
+/// :param: lhs The affected property. The associated view will have
+///             `translatesAutoresizingMaskIntoConstraints` set to `false`.
+/// :param: rhs The other property.
+///
+/// :returns: An `NSLayoutConstraint`.
+///
+public func <= <P: RelativeCompoundInequality>(lhs: P, rhs: P) -> [NSLayoutConstraint] {
+    return lhs.context.addConstraint(lhs, to: rhs, relation: NSLayoutRelation.LessThanOrEqual)
+}
+
+/// Declares a property greater than or equal to another compound property.
+///
+/// :param: lhs The affected property. The associated view will have
+///             `translatesAutoresizingMaskIntoConstraints` set to `false`.
+/// :param: rhs The other property.
+///
+/// :returns: An `NSLayoutConstraint`.
+///
+public func >= <P: RelativeCompoundInequality>(lhs: P, rhs: P) -> [NSLayoutConstraint] {
+    return lhs.context.addConstraint(lhs, to: rhs, relation: NSLayoutRelation.GreaterThanOrEqual)
+}
+
+/// Declares a property less than or equal to the result of an expression.
+///
+/// :param: lhs The affected property. The associated view will have
+///             `translatesAutoresizingMaskIntoConstraints` set to `false`.
+/// :param: rhs The other property.
+///
+/// :returns: An `NSLayoutConstraint`.
+///
+public func <= <P: RelativeCompoundInequality>(lhs: P, rhs: Expression<P>) -> [NSLayoutConstraint] {
+    return lhs.context.addConstraint(lhs, coefficients: rhs.coefficients, to: rhs.value, relation: NSLayoutRelation.LessThanOrEqual)
+}
+
+/// Declares a property greater than or equal to the result of an expression.
+///
+/// :param: lhs The affected property. The associated view will have
+///             `translatesAutoresizingMaskIntoConstraints` set to `false`.
+/// :param: rhs The other property.
+///
+/// :returns: An `NSLayoutConstraint`.
+///
+public func >= <P: RelativeCompoundInequality>(lhs: P, rhs: Expression<P>) -> [NSLayoutConstraint] {
+    return lhs.context.addConstraint(lhs, coefficients: rhs.coefficients, to: rhs.value, relation: NSLayoutRelation.GreaterThanOrEqual)
 }

--- a/Cartography/Dimension.swift
+++ b/Cartography/Dimension.swift
@@ -12,28 +12,14 @@ import UIKit
 import AppKit
 #endif
 
-public enum Dimension : Property, NumericalEquality, RelativeEquality, NumericalInequality, RelativeInequality, Addition, Multiplication {
-    case Width(Context, View)
-    case Height(Context, View)
+public struct Dimension : Property, NumericalEquality, RelativeEquality, NumericalInequality, RelativeInequality, Addition, Multiplication {
+    public let attribute: NSLayoutAttribute
+    public let context: Context
+    public let view: View
 
-    public var attribute: NSLayoutAttribute {
-        switch (self) {
-            case .Width(_): return NSLayoutAttribute.Width
-            case .Height(_): return NSLayoutAttribute.Height
-        }
-    }
-
-    public var context: Context {
-        switch (self) {
-            case let .Width(context, _): return context
-            case let .Height(context, _): return context
-        }
-    }
-
-    public var view: View {
-        switch (self) {
-            case let .Width(_, view): return view
-            case let .Height(_, view): return view
-        }
+    internal init(_ context: Context, _ view: View, _ attribute: NSLayoutAttribute) {
+        self.attribute = attribute
+        self.context = context
+        self.view = view
     }
 }

--- a/Cartography/Edge.swift
+++ b/Cartography/Edge.swift
@@ -12,120 +12,14 @@ import UIKit
 import AppKit
 #endif
 
-public enum Edge : Property, RelativeEquality, RelativeInequality, Addition, Multiplication {
-    case Top(Context, View)
-    case Right(Context, View)
-    case Bottom(Context, View)
-    case Left(Context, View)
+public struct Edge : Property, RelativeEquality, RelativeInequality, Addition, Multiplication {
+    public let attribute: NSLayoutAttribute
+    public let context: Context
+    public let view: View
 
-    case Leading(Context, View)
-    case Trailing(Context, View)
-
-    case CenterX(Context, View)
-    case CenterY(Context, View)
-
-    case Baseline(Context, View)
-
-    // The following properties are iOS exclusive and cannot have their
-    // `attribute` resolved on OS X.
-    case FirstBaseline(Context, View)
-    case LeftMargin(Context, View)
-    case RightMargin(Context, View)
-    case TopMargin(Context, View)
-    case BottomMargin(Context, View)
-    case LeadingMargin(Context, View)
-    case TrailingMargin(Context, View)
-    case CenterXWithinMargins(Context, View)
-    case CenterYWithinMargins(Context, View)
-
-    public var attribute: NSLayoutAttribute {
-        switch (self) {
-        case .Top(_): return .Top
-        case .Right(_): return .Right
-        case .Bottom(_): return .Bottom
-        case .Left(_): return .Left
-        case .Leading(_): return .Leading
-        case .Trailing(_): return .Trailing
-        case .CenterX(_): return .CenterX
-        case .CenterY(_): return .CenterY
-        case .Baseline(_): return .Baseline
-
-        // Swift does not let me mix `#if` statements with `case` statements as
-        // of Xcode 6.2
-        default:
-            #if os(iOS)
-            // Only on iOS we're able to look up the appropriate properties for
-            // the remaining cases.
-            switch (self) {
-            case .FirstBaseline(_): return .FirstBaseline
-            case .LeftMargin(_): return .LeftMargin
-            case .RightMargin(_): return .RightMargin
-            case .TopMargin(_): return .TopMargin
-            case .BottomMargin(_): return .BottomMargin
-            case .LeadingMargin(_): return .LeadingMargin
-            case .TrailingMargin(_): return .TrailingMargin
-            case .CenterXWithinMargins(_): return .CenterXWithinMargins
-            case .CenterYWithinMargins(_): return .CenterYWithinMargins
-            default:
-                fatalError("Unexpected case \(self).")
-                return .NotAnAttribute
-            }
-            #else
-            // Since `LayoutProxy` does not expose them on OS X, we should never
-            // have to resolve them.
-            fatalError("\(self) must not be used on OS X.")
-            return .NotAnAttribute
-            #endif
-        }
-    }
-
-    public var context: Context {
-        switch (self) {
-        case let .Top(context, _): return context
-        case let .Right(context, _): return context
-        case let .Bottom(context, _): return context
-        case let .Left(context, _): return context
-        case let .Leading(context, _): return context
-        case let .Trailing(context, _): return context
-        case let .CenterX(context, _): return context
-        case let .CenterY(context, _): return context
-        case let .Baseline(context, _): return context
-
-        // iOS Only
-        case let .FirstBaseline(context, _): return context
-        case let .LeftMargin(context, _): return context
-        case let .RightMargin(context, _): return context
-        case let .TopMargin(context, _): return context
-        case let .BottomMargin(context, _): return context
-        case let .LeadingMargin(context, _): return context
-        case let .TrailingMargin(context, _): return context
-        case let .CenterXWithinMargins(context, _): return context
-        case let .CenterYWithinMargins(context, _): return context
-        }
-    }
-
-    public var view: View {
-        switch (self) {
-        case let .Top(_, view): return view
-        case let .Right(_, view): return view
-        case let .Bottom(_, view): return view
-        case let .Left(_, view): return view
-        case let .Leading(_, view): return view
-        case let .Trailing(_, view): return view
-        case let .CenterX(_, view): return view
-        case let .CenterY(_, view): return view
-        case let .Baseline(_, view): return view
-
-        // iOS Only
-        case let .FirstBaseline(_, view): return view
-        case let .LeftMargin(_, view): return view
-        case let .RightMargin(_, view): return view
-        case let .TopMargin(_, view): return view
-        case let .BottomMargin(_, view): return view
-        case let .LeadingMargin(_, view): return view
-        case let .TrailingMargin(_, view): return view
-        case let .CenterXWithinMargins(_, view): return view
-        case let .CenterYWithinMargins(_, view): return view
-        }
+    internal init(_ context: Context, _ view: View, _ attribute: NSLayoutAttribute) {
+        self.attribute = attribute
+        self.context = context
+        self.view = view
     }
 }

--- a/Cartography/Edges.swift
+++ b/Cartography/Edges.swift
@@ -12,9 +12,9 @@ import UIKit
 import AppKit
 #endif
 
-public struct Edges: Compound {
-    let context: Context
-    let properties: [Property]
+public struct Edges: Compound, RelativeCompoundEquality, RelativeCompoundInequality {
+    public let context: Context
+    public let properties: [Property]
 
     internal init(_ context: Context, _ properties: [Property]) {
         self.context = context
@@ -64,80 +64,4 @@ public func inset(edges: Edges, top: Number, leading: Number, bottom: Number, tr
         Coefficients(1, -bottom.doubleValue),
         Coefficients(1, -trailing.doubleValue)
     ])
-}
-
-// MARK: Equality
-
-/// Declares a property equal to the result of an expression.
-///
-/// :param: lhs The affected property. The associated view will have
-///             `translatesAutoresizingMaskIntoConstraints` set to `false`.
-/// :param: rhs The expression.
-///
-/// :returns: An `NSLayoutConstraint`.
-///
-public func == (lhs: Edges, rhs: Expression<Edges>) -> [NSLayoutConstraint] {
-    return lhs.context.addConstraint(lhs, coefficients: rhs.coefficients, to: rhs.value)
-}
-
-/// Declares a property equal to another property.
-///
-/// :param: lhs The affected property. The associated view will have
-///             `translatesAutoresizingMaskIntoConstraints` set to `false`.
-/// :param: rhs The other property.
-///
-/// :returns: An `NSLayoutConstraint`.
-///
-public func == (lhs: Edges, rhs: Edges) -> [NSLayoutConstraint] {
-    return lhs.context.addConstraint(lhs, to: rhs)
-}
-
-// MARK: Inequality
-
-/// Declares a property less than or equal to another property.
-///
-/// :param: lhs The affected property. The associated view will have
-///             `translatesAutoresizingMaskIntoConstraints` set to `false`.
-/// :param: rhs The other property.
-///
-/// :returns: An `NSLayoutConstraint`.
-///
-public func <= (lhs: Edges, rhs: Edges) -> [NSLayoutConstraint] {
-    return lhs.context.addConstraint(lhs, to: rhs, relation: NSLayoutRelation.LessThanOrEqual)
-}
-
-/// Declares a property greater than or equal to another property.
-///
-/// :param: lhs The affected property. The associated view will have
-///             `translatesAutoresizingMaskIntoConstraints` set to `false`.
-/// :param: rhs The other property.
-///
-/// :returns: An `NSLayoutConstraint`.
-///
-public func >= (lhs: Edges, rhs: Edges) -> [NSLayoutConstraint] {
-    return lhs.context.addConstraint(lhs, to: rhs, relation: NSLayoutRelation.GreaterThanOrEqual)
-}
-
-/// Declares a property less than or equal to the result of an expression.
-///
-/// :param: lhs The affected property. The associated view will have
-///             `translatesAutoresizingMaskIntoConstraints` set to `false`.
-/// :param: rhs The expression.
-///
-/// :returns: An `NSLayoutConstraint`.
-///
-public func <= (lhs: Edges, rhs: Expression<Edges>) -> [NSLayoutConstraint] {
-    return lhs.context.addConstraint(lhs, coefficients: rhs.coefficients, to: rhs.value, relation: NSLayoutRelation.LessThanOrEqual)
-}
-
-/// Declares a property greater than or equal to the result of an expression.
-///
-/// :param: lhs The affected property. The associated view will have
-///             `translatesAutoresizingMaskIntoConstraints` set to `false`.
-/// :param: rhs The expression.
-///
-/// :returns: An `NSLayoutConstraint`.
-///
-public func >= (lhs: Edges, rhs: Expression<Edges>) -> [NSLayoutConstraint] {
-    return lhs.context.addConstraint(lhs, coefficients: rhs.coefficients, to: rhs.value, relation: NSLayoutRelation.GreaterThanOrEqual)
 }

--- a/Cartography/Edges.swift
+++ b/Cartography/Edges.swift
@@ -12,26 +12,13 @@ import UIKit
 import AppKit
 #endif
 
-public enum Edges : Compound {
-    case Edges(Context, View)
+public struct Edges: Compound {
+    let context: Context
+    let properties: [Property]
 
-    var context: Context {
-        switch (self) {
-            case let .Edges(context, _):
-                return context
-        }
-    }
-
-    var properties: [Property] {
-        switch (self) {
-            case let .Edges(context, view):
-                return [
-                    Edge.Top(context, view),
-                    Edge.Leading(context, view),
-                    Edge.Bottom(context, view),
-                    Edge.Trailing(context, view)
-                ]
-        }
+    internal init(_ context: Context, _ properties: [Property]) {
+        self.context = context
+        self.properties = properties
     }
 }
 

--- a/Cartography/LayoutProxy.swift
+++ b/Cartography/LayoutProxy.swift
@@ -102,41 +102,55 @@ public class LayoutProxy {
         self.context = context
         self.view = view
 
-        width  = Dimension.Width(context, view)
-        height = Dimension.Height(context, view)
+        width  = Dimension(context, view, .Width)
+        height = Dimension(context, view, .Height)
 
-        size = Size.Size(context, view)
+        size = Size(context, [
+            Dimension(context, view, .Width),
+            Dimension(context, view, .Height)
+        ])
 
-        top    = Edge.Top(context, view)
-        right  = Edge.Right(context, view)
-        bottom = Edge.Bottom(context, view)
-        left   = Edge.Left(context, view)
+        top    = Edge(context, view, .Top)
+        right  = Edge(context, view, .Right)
+        bottom = Edge(context, view, .Bottom)
+        left   = Edge(context, view, .Left)
 
-        edges = Edges.Edges(context, view)
+        edges = Edges(context, [
+            Edge(context, view, .Top),
+            Edge(context, view, .Leading),
+            Edge(context, view, .Bottom),
+            Edge(context, view, .Trailing)
+        ])
 
-        leading = Edge.Leading(context, view)
-        trailing = Edge.Trailing(context, view)
+        leading = Edge(context, view, .Leading)
+        trailing = Edge(context, view, .Trailing)
 
-        centerX = Edge.CenterX(context, view)
-        centerY = Edge.CenterY(context, view)
+        centerX = Edge(context, view, .CenterX)
+        centerY = Edge(context, view, .CenterY)
 
-        center = Point.Center(context, view)
+        center = Point(context, [
+            Edge(context, view, .CenterX),
+            Edge(context, view, .CenterY)
+        ])
 
-        baseline = Edge.Baseline(context, view)
+        baseline = Edge(context, view, .Baseline)
 
         #if os(iOS)
-        firstBaseline = .FirstBaseline(context, view)
+        firstBaseline = Edge(context, view, .FirstBaseline)
 
-        leftMargin = .LeftMargin(context, view)
-        rightMargin = .RightMargin(context, view)
-        topMargin = .TopMargin(context, view)
-        bottomMargin = .BottomMargin(context, view)
-        leadingMargin = .LeadingMargin(context, view)
-        trailingMargin = .TrailingMargin(context, view)
-        centerXWithinMargins = .CenterXWithinMargins(context, view)
-        centerYWithinMargins = .CenterYWithinMargins(context, view)
+        leftMargin = Edge(context, view, .LeftMargin)
+        rightMargin = Edge(context, view, .RightMargin)
+        topMargin = Edge(context, view, .TopMargin)
+        bottomMargin = Edge(context, view, .BottomMargin)
+        leadingMargin = Edge(context, view, .LeadingMargin)
+        trailingMargin = Edge(context, view, .TrailingMargin)
+        centerXWithinMargins = Edge(context, view, .CenterXWithinMargins)
+        centerYWithinMargins = Edge(context, view, .CenterYWithinMargins)
 
-        centerWithinMargins = .CenterWithinMargins(context, view)
+        centerWithinMargins = Point(context, [
+            Edge(context, view, .CenterXWithinMargins),
+            Edge(context, view, .CenterYWithinMargins)
+        ])
         #endif
     }
 }

--- a/Cartography/Point.swift
+++ b/Cartography/Point.swift
@@ -12,88 +12,12 @@ import UIKit
 import AppKit
 #endif
 
-public struct Point: Compound {
-    let context: Context
-    let properties: [Property]
+public struct Point: Compound, RelativeCompoundEquality, RelativeCompoundInequality {
+    public let context: Context
+    public let properties: [Property]
 
     internal init(_ context: Context, _ properties: [Property]) {
         self.context = context
         self.properties = properties
     }
-}
-
-// MARK: Equality
-
-/// Declares a property equal to the result of an expression.
-///
-/// :param: lhs The affected property. The associated view will have
-///             `translatesAutoresizingMaskIntoConstraints` set to `false`.
-/// :param: rhs The expression.
-///
-/// :returns: An `NSLayoutConstraint`.
-///
-public func == (lhs: Point, rhs: Expression<Point>) -> [NSLayoutConstraint] {
-    return lhs.context.addConstraint(lhs, coefficients: rhs.coefficients, to: rhs.value)
-}
-
-/// Declares a property equal to another property.
-///
-/// :param: lhs The affected property. The associated view will have
-///             `translatesAutoresizingMaskIntoConstraints` set to `false`.
-/// :param: rhs The other property.
-///
-/// :returns: An `NSLayoutConstraint`.
-///
-public func == (lhs: Point, rhs: Point) -> [NSLayoutConstraint] {
-    return lhs.context.addConstraint(lhs, to: rhs)
-}
-
-// MARK: Inequality
-
-/// Declares a property less than or equal to another property.
-///
-/// :param: lhs The affected property. The associated view will have
-///             `translatesAutoresizingMaskIntoConstraints` set to `false`.
-/// :param: rhs The other property.
-///
-/// :returns: An `NSLayoutConstraint`.
-///
-public func <= (lhs: Point, rhs: Point) -> [NSLayoutConstraint] {
-    return lhs.context.addConstraint(lhs, to: rhs, relation: NSLayoutRelation.LessThanOrEqual)
-}
-
-/// Declares a property greater than or equal to another property.
-///
-/// :param: lhs The affected property. The associated view will have
-///             `translatesAutoresizingMaskIntoConstraints` set to `false`.
-/// :param: rhs The other property.
-///
-/// :returns: An `NSLayoutConstraint`.
-///
-public func >= (lhs: Point, rhs: Point) -> [NSLayoutConstraint] {
-    return lhs.context.addConstraint(lhs, to: rhs, relation: NSLayoutRelation.GreaterThanOrEqual)
-}
-
-/// Declares a property less than or equal to the result of an expression.
-///
-/// :param: lhs The affected property. The associated view will have
-///             `translatesAutoresizingMaskIntoConstraints` set to `false`.
-/// :param: rhs The expression.
-///
-/// :returns: An `NSLayoutConstraint`.
-///
-public func <= (lhs: Point, rhs: Expression<Point>) -> [NSLayoutConstraint] {
-    return lhs.context.addConstraint(lhs, coefficients: rhs.coefficients, to: rhs.value, relation: NSLayoutRelation.LessThanOrEqual)
-}
-
-/// Declares a property greater than or equal to the result of an expression.
-///
-/// :param: lhs The affected property. The associated view will have
-///             `translatesAutoresizingMaskIntoConstraints` set to `false`.
-/// :param: rhs The expression.
-///
-/// :returns: An `NSLayoutConstraint`.
-///
-public func >= (lhs: Point, rhs: Expression<Point>) -> [NSLayoutConstraint] {
-    return lhs.context.addConstraint(lhs, coefficients: rhs.coefficients, to: rhs.value, relation: NSLayoutRelation.GreaterThanOrEqual)
 }

--- a/Cartography/Point.swift
+++ b/Cartography/Point.swift
@@ -12,32 +12,13 @@ import UIKit
 import AppKit
 #endif
 
-public enum Point: Compound {
-    case Center(Context, View)
-    case CenterWithinMargins(Context, View)
+public struct Point: Compound {
+    let context: Context
+    let properties: [Property]
 
-    var context: Context {
-        switch (self) {
-        case let .Center(context, _):
-            return context
-        case let .CenterWithinMargins(context, _):
-            return context
-        }
-    }
-
-    var properties: [Property] {
-        switch (self) {
-        case let .Center(context, view):
-            return [
-                Edge.CenterX(context, view),
-                Edge.CenterY(context, view)
-            ]
-        case let .CenterWithinMargins(context, view):
-            return [
-                Edge.CenterXWithinMargins(context, view),
-                Edge.CenterYWithinMargins(context, view)
-            ]
-        }
+    internal init(_ context: Context, _ properties: [Property]) {
+        self.context = context
+        self.properties = properties
     }
 }
 

--- a/Cartography/Size.swift
+++ b/Cartography/Size.swift
@@ -12,90 +12,14 @@ import UIKit
 import AppKit
 #endif
 
-public struct Size : Compound {
-    let context: Context
-    let properties: [Property]
+public struct Size : Compound, RelativeCompoundEquality, RelativeCompoundInequality {
+    public let context: Context
+    public let properties: [Property]
 
     internal init(_ context: Context, _ properties: [Property]) {
         self.context = context
         self.properties = properties
     }
-}
-
-// MARK: Equality
-
-/// Declares a property equal to the result of an expression.
-///
-/// :param: lhs The affected property. The associated view will have
-///             `translatesAutoresizingMaskIntoConstraints` set to `false`.
-/// :param: rhs The expression.
-///
-/// :returns: An `NSLayoutConstraint`.
-///
-public func == (lhs: Size, rhs: Expression<Size>) -> [NSLayoutConstraint] {
-    return lhs.context.addConstraint(lhs, coefficients: rhs.coefficients, to: rhs.value)
-}
-
-/// Declares a property equal to another property.
-///
-/// :param: lhs The affected property. The associated view will have
-///             `translatesAutoresizingMaskIntoConstraints` set to `false`.
-/// :param: rhs The other property.
-///
-/// :returns: An `NSLayoutConstraint`.
-///
-public func == (lhs: Size, rhs: Size) -> [NSLayoutConstraint] {
-    return lhs.context.addConstraint(lhs, to: rhs)
-}
-
-// MARK: Inequality
-
-/// Declares a property less than or equal to another property.
-///
-/// :param: lhs The affected property. The associated view will have
-///             `translatesAutoresizingMaskIntoConstraints` set to `false`.
-/// :param: rhs The other property.
-///
-/// :returns: An `NSLayoutConstraint`.
-///
-public func <= (lhs: Size, rhs: Size) -> [NSLayoutConstraint] {
-    return lhs.context.addConstraint(lhs, to: rhs, relation: NSLayoutRelation.LessThanOrEqual)
-}
-
-/// Declares a property greater than or equal to another property.
-///
-/// :param: lhs The affected property. The associated view will have
-///             `translatesAutoresizingMaskIntoConstraints` set to `false`.
-/// :param: rhs The other property.
-///
-/// :returns: An `NSLayoutConstraint`.
-///
-public func >= (lhs: Size, rhs: Size) -> [NSLayoutConstraint] {
-    return lhs.context.addConstraint(lhs, to: rhs, relation: NSLayoutRelation.GreaterThanOrEqual)
-}
-
-/// Declares a property less than or equal to the result of an expression.
-///
-/// :param: lhs The affected property. The associated view will have
-///             `translatesAutoresizingMaskIntoConstraints` set to `false`.
-/// :param: rhs The expression.
-///
-/// :returns: An `NSLayoutConstraint`.
-///
-public func <= (lhs: Size, rhs: Expression<Size>) -> [NSLayoutConstraint] {
-    return lhs.context.addConstraint(lhs, coefficients: rhs.coefficients, to: rhs.value, relation: NSLayoutRelation.LessThanOrEqual)
-}
-
-/// Declares a property greater than or equal to the result of an expression.
-///
-/// :param: lhs The affected property. The associated view will have
-///             `translatesAutoresizingMaskIntoConstraints` set to `false`.
-/// :param: rhs The expression.
-///
-/// :returns: An `NSLayoutConstraint`.
-///
-public func >= (lhs: Size, rhs: Expression<Size>) -> [NSLayoutConstraint] {
-    return lhs.context.addConstraint(lhs, coefficients: rhs.coefficients, to: rhs.value, relation: NSLayoutRelation.GreaterThanOrEqual)
 }
 
 // MARK: Multiplication

--- a/Cartography/Size.swift
+++ b/Cartography/Size.swift
@@ -12,21 +12,13 @@ import UIKit
 import AppKit
 #endif
 
-public enum Size : Compound {
-    case Size(Context, View)
+public struct Size : Compound {
+    let context: Context
+    let properties: [Property]
 
-    var context: Context {
-        switch (self) {
-            case let .Size(context, _):
-                return context
-        }
-    }
-
-    var properties: [Property] {
-        switch (self) {
-            case let .Size(context, view):
-                return [ Dimension.Width(context, view), Dimension.Height(context, view) ]
-        }
+    internal init(_ context: Context, _ properties: [Property]) {
+        self.context = context
+        self.properties = properties
     }
 }
 


### PR DESCRIPTION
This replaces all enums with vastly simpler structs and also moves the operators for `Compound` properties into protocols.

Depends on  #93 