### PR TITLE
Fixed “Use of undeclared type ‘NSLayoutConstraint’ error.

### DIFF
--- a/Cartography/Distribute.swift
+++ b/Cartography/Distribute.swift
@@ -6,7 +6,11 @@
 //  Copyright (c) 2015 Robert Böhnke. All rights reserved.
 //
 
-import Foundation
+#if os(iOS)
+    import UIKit
+    #else
+    import AppKit
+#endif
 
 typealias Accumulator = ([NSLayoutConstraint], LayoutProxy)
 


### PR DESCRIPTION
To reproduce:

1. Clone Cartography (Xcode 6.3 branch)
2. Create an empty Cocoa Xcode project
3. Drag Cartography classes in to the new project (like some sort of animal, I know)
4. See error, above.

(Only noted above as same class works in original project. Haven’t looked into why/how.)