### PR TITLE
Allow distributing arrays of views

### DIFF
--- a/Cartography/Distribute.swift
+++ b/Cartography/Distribute.swift
@@ -24,6 +24,7 @@ private func reduce(first: LayoutProxy, rest: [LayoutProxy], combine: (LayoutPro
     }.0
 }
 
+
 /// Distributes multiple views horizontally.
 ///
 /// All views passed to this function will have
@@ -35,8 +36,25 @@ private func reduce(first: LayoutProxy, rest: [LayoutProxy], combine: (LayoutPro
 /// :returns: An array of `NSLayoutConstraint` instances.
 ///
 public func distribute(by amount: CGFloat, horizontally first: LayoutProxy, rest: LayoutProxy...) -> [NSLayoutConstraint] {
-    return reduce(first, rest) { $0.trailing == $1.leading - amount }
+    return distribute(by: amount, horizontally: [first] + rest)
 }
+
+
+/// Distributes multiple views horizontally.
+///
+/// All views passed to this function will have
+/// their `translatesAutoresizingMaskIntoConstraints` properties set to `false`.
+///
+/// :param: amount The distance between the views.
+/// :param: views  The views to distribute.
+///
+/// :returns: An array of `NSLayoutConstraint` instances.
+///
+
+public func distribute(by amount: CGFloat, horizontally views: [LayoutProxy]) -> [NSLayoutConstraint] {
+    return reduce(views.first!, Array(views[1..<views.count])) { $0.trailing == $1.leading - amount }
+}
+
 
 /// Distributes multiple views horizontally from left to right.
 ///
@@ -49,8 +67,24 @@ public func distribute(by amount: CGFloat, horizontally first: LayoutProxy, rest
 /// :returns: An array of `NSLayoutConstraint` instances.
 ///
 public func distribute(by amount: CGFloat, leftToRight first: LayoutProxy, rest: LayoutProxy...) -> [NSLayoutConstraint] {
-    return reduce(first, rest) { $0.right == $1.left - amount  }
+    return distribute(by: amount, leftToRight: [first] + rest)
 }
+
+
+/// Distributes multiple views horizontally from left to right.
+///
+/// All views passed to this function will have
+/// their `translatesAutoresizingMaskIntoConstraints` properties set to `false`.
+///
+/// :param: amount The distance between the views.
+/// :param: views  The views to distribute.
+///
+/// :returns: An array of `NSLayoutConstraint` instances.
+///
+public func distribute(by amount: CGFloat, leftToRight views: [LayoutProxy]) -> [NSLayoutConstraint] {
+    return reduce(views.first!, Array(views[1..<views.count])) { $0.right == $1.left - amount  }
+}
+
 
 /// Distributes multiple views vertically.
 ///
@@ -63,5 +97,20 @@ public func distribute(by amount: CGFloat, leftToRight first: LayoutProxy, rest:
 /// :returns: An array of `NSLayoutConstraint` instances.
 ///
 public func distribute(by amount: CGFloat, vertically first: LayoutProxy, rest: LayoutProxy...) -> [NSLayoutConstraint] {
-    return reduce(first, rest) { $0.bottom == $1.top - amount }
+    return distribute(by: amount, vertically: [first] + rest)
+}
+
+
+/// Distributes multiple views vertically.
+///
+/// All views passed to this function will have
+/// their `translatesAutoresizingMaskIntoConstraints` properties set to `false`.
+///
+/// :param: amount The distance between the views.
+/// :param: views  The views to distribute.
+///
+/// :returns: An array of `NSLayoutConstraint` instances.
+///
+public func distribute(by amount: CGFloat, vertically views: [LayoutProxy]) -> [NSLayoutConstraint] {
+    return reduce(views.first!, Array(views[1..<views.count])) { $0.bottom == $1.top - amount }
 }

--- a/Cartography/Distribute.swift
+++ b/Cartography/Distribute.swift
@@ -14,7 +14,7 @@
 
 typealias Accumulator = ([NSLayoutConstraint], LayoutProxy)
 
-private func reduce(first: LayoutProxy, rest: [LayoutProxy], combine: (LayoutProxy, LayoutProxy) -> NSLayoutConstraint) -> [NSLayoutConstraint] {
+private func reduce(first: LayoutProxy, rest: ArraySlice<LayoutProxy>, combine: (LayoutProxy, LayoutProxy) -> NSLayoutConstraint) -> [NSLayoutConstraint] {
     rest.last?.view.car_translatesAutoresizingMaskIntoConstraints = false
 
     return reduce(rest, ([], first)) { (acc, current) -> Accumulator in
@@ -52,7 +52,7 @@ public func distribute(by amount: CGFloat, horizontally first: LayoutProxy, rest
 ///
 
 public func distribute(by amount: CGFloat, horizontally views: [LayoutProxy]) -> [NSLayoutConstraint] {
-    return reduce(views.first!, Array(views[1..<views.count])) { $0.trailing == $1.leading - amount }
+    return reduce(views.first!, views[1..<views.count]) { $0.trailing == $1.leading - amount }
 }
 
 
@@ -82,7 +82,7 @@ public func distribute(by amount: CGFloat, leftToRight first: LayoutProxy, rest:
 /// :returns: An array of `NSLayoutConstraint` instances.
 ///
 public func distribute(by amount: CGFloat, leftToRight views: [LayoutProxy]) -> [NSLayoutConstraint] {
-    return reduce(views.first!, Array(views[1..<views.count])) { $0.right == $1.left - amount  }
+    return reduce(views.first!, views[1..<views.count]) { $0.right == $1.left - amount  }
 }
 
 
@@ -112,5 +112,5 @@ public func distribute(by amount: CGFloat, vertically first: LayoutProxy, rest: 
 /// :returns: An array of `NSLayoutConstraint` instances.
 ///
 public func distribute(by amount: CGFloat, vertically views: [LayoutProxy]) -> [NSLayoutConstraint] {
-    return reduce(views.first!, Array(views[1..<views.count])) { $0.bottom == $1.top - amount }
+    return reduce(views.first!, views[1..<views.count]) { $0.bottom == $1.top - amount }
 }

--- a/CartographyTests/DistributeSpec.swift
+++ b/CartographyTests/DistributeSpec.swift
@@ -75,5 +75,47 @@ class DistributeSpec: QuickSpec {
                 expect(viewC.car_translatesAutoresizingMaskIntoConstraints).to(beFalse())
             }
         }
+        
+        describe("horizontally with array of views") {
+            beforeEach {
+                layout([viewA, viewB, viewC]) { views in
+                    align(centerY: views[0], views[1], views[2])
+                    distribute(by: 10, leftToRight: views)
+                }
+                
+                it("should distribute the views") {
+                    expect(viewA.frame.minX).to(equal(  0))
+                    expect(viewB.frame.minX).to(equal(110))
+                    expect(viewC.frame.minX).to(equal(220))
+                }
+                
+                it("should disable translating autoresizing masks into constraints") {
+                    expect(viewA.car_translatesAutoresizingMaskIntoConstraints).to(beFalse())
+                    expect(viewB.car_translatesAutoresizingMaskIntoConstraints).to(beFalse())
+                    expect(viewC.car_translatesAutoresizingMaskIntoConstraints).to(beFalse())
+                }
+            }
+        }
+        
+        describe("vertically with array of views") {
+            beforeEach {
+                layout([viewA, viewB, viewC]) { views in
+                    align(centerY: views[0], views[1], views[2])
+                    distribute(by: 10, leftToRight: views)
+                }
+                
+                it("should distribute the views") {
+                    expect(viewA.frame.minY).to(equal(  0))
+                    expect(viewB.frame.minY).to(equal(110))
+                    expect(viewC.frame.minY).to(equal(220))
+                }
+                
+                it("should disable translating autoresizing masks into constraints") {
+                    expect(viewA.car_translatesAutoresizingMaskIntoConstraints).to(beFalse())
+                    expect(viewB.car_translatesAutoresizingMaskIntoConstraints).to(beFalse())
+                    expect(viewC.car_translatesAutoresizingMaskIntoConstraints).to(beFalse())
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
This makes sense since layout can take an array and returns an array.  It should be possible to distribute an array of views.  

This pull request achieves that by modifying the existing distribute functions to accept an array, and then rewriting the originals as wrappers.
