### PR TITLE
Remove @objc declaration of the class Constraint

### DIFF
--- a/Cartography/Constraint.swift
+++ b/Cartography/Constraint.swift
@@ -12,7 +12,6 @@ import UIKit
 import AppKit
 #endif
 
-@objc
 internal class Constraint {
     // Set to weak to avoid a retain cycle on the associated view.
     weak var view: View?


### PR DESCRIPTION
This is to fix the following compiler error:
```error: only classes that inherit from NSObject can be declared @objc```