### PR TITLE
Warnings when building with Carthage

### DIFF
--- a/Cartography.xcodeproj/project.pbxproj
+++ b/Cartography.xcodeproj/project.pbxproj
@@ -909,10 +909,6 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
 				INFOPLIST_FILE = Cartography/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -934,10 +930,6 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
 				INFOPLIST_FILE = Cartography/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -994,10 +986,6 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/Mac",
-				);
 				FRAMEWORK_VERSION = A;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -1025,10 +1013,6 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/Mac",
-				);
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = Cartography/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";


### PR DESCRIPTION
When I have Cartography in my Cartfile and run `carthage bootstrap` from a clean state (`rm -r Carthage`), I see some warnings:
```
*** Checking out Cartography at "0.6.0"
*** xcodebuild output can be found in /var/folders/m3/0g6_fk1n1pqb2kfq256zdwrw0000gp/T/carthage-xcodebuild.huS7L2.log
*** Building scheme "Cartography-iOS" in Cartography.xcodeproj
ld: warning: directory not found for option '-F/Users/asana/Documents/ios/Carthage/Checkouts/Cartography/Carthage/Build/iOS'
ld: warning: directory not found for option '-F/Users/asana/Documents/ios/Carthage/Checkouts/Cartography/Carthage/Build/iOS'
ld: warning: directory not found for option '-F/Users/asana/Documents/ios/Carthage/Checkouts/Cartography/Carthage/Build/iOS'
ld: warning: directory not found for option '-F/Users/asana/Documents/ios/Carthage/Checkouts/Cartography/Carthage/Build/iOS'
```

The cause appears to be that directory featured in the framework search path is not created when Cartography's private dependencies are not built, because it has no non-private dependencies.

My solution is to remove the framework search path from the framework targets.