### PR TITLE
Added the lastBaseline property to LayoutProxy

### DIFF
--- a/Cartography/LayoutProxy.swift
+++ b/Cartography/LayoutProxy.swift
@@ -92,6 +92,11 @@ public struct LayoutProxy {
         return Edge(context, view, .Baseline)
     }
 
+    /// The last baseline of the view.
+    public var lastBaseline: Edge {
+        return Edge(context, view, .LastBaseline)
+    }
+    
     #if os(iOS) || os(tvOS)
     /// The first baseline of the view. iOS exclusive.
     @available(iOS, introduced=8.0)


### PR DESCRIPTION
`LayoutProxy` didn't have a property for `NSLayoutAttribute.LastBaseline` so I added it myself. Or is there a reason for why it's missing?

I tested the code in my application and it looks like it's working.