### PR TITLE
Allow insetting edges using UIEdgeInsets

### DIFF
--- a/Cartography/Edges.swift
+++ b/Cartography/Edges.swift
@@ -65,3 +65,14 @@ public func inset(edges: Edges, _ top: CGFloat, _ leading: CGFloat, _ bottom: CG
         Coefficients(1, -trailing)
     ])
 }
+
+/// Insets edges individually with UIEdgeInset.
+///
+/// - parameter edges:    The edges to inset.
+/// - parameter insets:   The amounts by which to inset all edges, in points via UIEdgeInsets.
+///
+/// - returns: A new expression with the inset edges.
+///
+public func inset(edges: Edges, _ insets: UIEdgeInsets) -> Expression<Edges> {
+    return inset(edges, insets.top, insets.left, insets.bottom, insets.right)
+}


### PR DESCRIPTION
Adds a helper `inset` with takes a UIEdgeInsets parameter instead of specifying each edge separately.