### PR TITLE
Allow unlimited amount of views to be used in the constrain function

### DIFF
--- a/Cartography/Constrain.swift
+++ b/Cartography/Constrain.swift
@@ -7,89 +7,22 @@
 //
 
 import Foundation
+import UIKit
 
 /// Updates the constraints of a single view.
 ///
-/// - parameter view:    The view to layout.
+/// - parameter views:    The views to layout.
 /// - parameter replace: The `ConstraintGroup` whose constraints should be
 ///                      replaced.
 /// - parameter block:   A block that declares the layout for `view`.
 ///
-public func constrain(view: View, replace group: ConstraintGroup = ConstraintGroup(), @noescape block: LayoutProxy -> ()) -> ConstraintGroup {
+public func constrain(views: View..., replace group: ConstraintGroup = ConstraintGroup(), @noescape block: LayoutProxy -> ()) -> ConstraintGroup {
     let context = Context()
-    block(LayoutProxy(context, view))
+    for view in views {
+        block(LayoutProxy(context, view))
+    }
     group.replaceConstraints(context.constraints)
-
-    return group
-}
-
-/// Updates the constraints of two views.
-///
-/// - parameter view1:   A view to layout.
-/// - parameter view2:   A view to layout.
-/// - parameter replace: The `ConstraintGroup` whose constraints should be
-///                      replaced.
-/// - parameter block:   A block that declares the layout for the views.
-///
-public func constrain(view1: View, _ view2: View, replace group: ConstraintGroup = ConstraintGroup(), @noescape block: (LayoutProxy, LayoutProxy) -> ()) -> ConstraintGroup {
-    let context = Context()
-    block(LayoutProxy(context, view1), LayoutProxy(context, view2))
-    group.replaceConstraints(context.constraints)
-
-    return group
-}
-
-/// Updates the constraints of three views.
-///
-/// - parameter view1:   A view to layout.
-/// - parameter view2:   A view to layout.
-/// - parameter view3:   A view to layout.
-/// - parameter replace: The `ConstraintGroup` whose constraints should be
-///                      replaced.
-/// - parameter block:   A block that declares the layout for the views.
-///
-public func constrain(view1: View, _ view2: View, _ view3: View, replace group: ConstraintGroup = ConstraintGroup(), @noescape block: (LayoutProxy, LayoutProxy, LayoutProxy) -> ()) -> ConstraintGroup {
-    let context = Context()
-    block(LayoutProxy(context, view1), LayoutProxy(context, view2), LayoutProxy(context, view3))
-    group.replaceConstraints(context.constraints)
-
-    return group
-}
-
-/// Updates the constraints of four views.
-///
-/// - parameter view1:   A view to layout.
-/// - parameter view2:   A view to layout.
-/// - parameter view3:   A view to layout.
-/// - parameter view4:   A view to layout.
-/// - parameter replace: The `ConstraintGroup` whose constraints should be
-///                      replaced.
-/// - parameter block:   A block that declares the layout for the views.
-///
-public func constrain(view1: View, _ view2: View, _ view3: View, _ view4: View, replace group: ConstraintGroup = ConstraintGroup(), @noescape block: (LayoutProxy, LayoutProxy, LayoutProxy, LayoutProxy) -> ()) -> ConstraintGroup {
-    let context = Context()
-    block(LayoutProxy(context, view1), LayoutProxy(context, view2), LayoutProxy(context, view3), LayoutProxy(context, view4))
-    group.replaceConstraints(context.constraints)
-
-    return group
-}
-
-/// Updates the constraints of five views.
-///
-/// - parameter view1:   A view to layout.
-/// - parameter view2:   A view to layout.
-/// - parameter view3:   A view to layout.
-/// - parameter view4:   A view to layout.
-/// - parameter view5:   A view to layout.
-/// - parameter replace: The `ConstraintGroup` whose constraints should be
-///                      replaced.
-/// - parameter block:   A block that declares the layout for the views.
-///
-public func constrain(view1: View, _ view2: View, _ view3: View, _ view4: View, _ view5: View, replace group: ConstraintGroup = ConstraintGroup(), @noescape block: (LayoutProxy, LayoutProxy, LayoutProxy, LayoutProxy, LayoutProxy) -> ()) -> ConstraintGroup {
-    let context = Context()
-    block(LayoutProxy(context, view1), LayoutProxy(context, view2), LayoutProxy(context, view3), LayoutProxy(context, view4), LayoutProxy(context, view5))
-    group.replaceConstraints(context.constraints)
-
+    
     return group
 }
 
@@ -104,7 +37,7 @@ public func constrain(views: [View], replace group: ConstraintGroup = Constraint
     let context = Context()
     block(views.map({ LayoutProxy(context, $0) }))
     group.replaceConstraints(context.constraints)
-
+    
     return group
 }
 
@@ -120,7 +53,7 @@ public func constrain<T: Hashable>(views: [T: View], replace group: ConstraintGr
     let proxies = views.map { ($0, LayoutProxy(context, $1)) }
     block(Dictionary(proxies))
     group.replaceConstraints(context.constraints)
-
+    
     return group
 }
 


### PR DESCRIPTION
By using the `...`-postfix we can have an unlimited amount of views inside the `constrain()` function.
So we can do this: 

```swift
 constrain(UView(), UIView(), UIView(), UIView(), UIView(), UIView(), UIView(), UIView(), UIView()) { 
view1, view2, view3, view4, view5, view6, view7, view8, view9 in 


}
 ```

I found out about this behavior in the through the `print` function.