### PR TITLE
Allow insetting edges using UIEdgeInsets

### DIFF
--- a/Cartography/Edges.swift
+++ b/Cartography/Edges.swift
@@ -65,3 +65,16 @@ public func inset(edges: Edges, _ top: CGFloat, _ leading: CGFloat, _ bottom: CG
         Coefficients(1, -trailing)
     ])
 }
+
+#if os(iOS) || os(tvOS)
+/// Insets edges individually with UIEdgeInset.
+///
+/// - parameter edges:    The edges to inset.
+/// - parameter insets:   The amounts by which to inset all edges, in points via UIEdgeInsets.
+///
+/// - returns: A new expression with the inset edges.
+///
+public func inset(edges: Edges, _ insets: UIEdgeInsets) -> Expression<Edges> {
+    return inset(edges, insets.top, insets.left, insets.bottom, insets.right)
+}
+#endif

--- a/CartographyTests/EdgesSpec.swift
+++ b/CartographyTests/EdgesSpec.swift
@@ -90,6 +90,19 @@ class EdgesSpec: QuickSpec {
                 }
             }
         }
+        
+        describe("on iOS only, inset using UIEdgeInsets") {
+            it("should inset all edges individually") {
+                constrain(view) { view in
+                    let insets = UIEdgeInsets(top: 10, left: 20, bottom: 30, right: 40)
+                    view.edges == inset(view.superview!.edges, insets)
+                }
+
+                window.layoutIfNeeded()
+
+                expect(view.frame).to(equal(CGRectMake(20, 10, 340, 360)))
+            }
+        }
 #endif
     }
 }


### PR DESCRIPTION
Adds a helper `inset` with takes a UIEdgeInsets parameter instead of specifying each edge separately.

Fixed version of https://github.com/robb/Cartography/pull/194