### PR TITLE
Missing support for LayoutProxy array on functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ DerivedData
 *.xcuserstate
 
 Carthage/
+
+# Finder
+.DS_Store

--- a/Cartography/Align.swift
+++ b/Cartography/Align.swift
@@ -20,6 +20,15 @@ private func makeEqual<P: RelativeEquality>(attribute: LayoutProxy -> P, first: 
     }
 }
 
+private func makeEqual<P: RelativeEquality>(attribute: LayoutProxy -> P, views: [LayoutProxy]) -> [NSLayoutConstraint] {
+    let (first, rest) = splitLayoutProxyArray(views)
+    return rest.reduce([]) { acc, current in
+        current.view.car_translatesAutoresizingMaskIntoConstraints = false
+        
+        return acc + [ attribute(first) == attribute(current) ]
+    }
+}
+
 /// Aligns multiple views by their top edge.
 ///
 /// All views passed to this function will have
@@ -29,6 +38,10 @@ private func makeEqual<P: RelativeEquality>(attribute: LayoutProxy -> P, first: 
 ///
 public func align(top first: LayoutProxy, _ rest: LayoutProxy...) -> [NSLayoutConstraint] {
     return makeEqual({ $0.top }, first: first, rest: rest)
+}
+
+public func align(top views: [LayoutProxy]) -> [NSLayoutConstraint] {
+    return makeEqual({ $0.top }, views: views)
 }
 
 /// Aligns multiple views by their right edge.
@@ -42,6 +55,10 @@ public func align(right first: LayoutProxy, _ rest: LayoutProxy...) -> [NSLayout
     return makeEqual({ $0.right }, first: first, rest: rest)
 }
 
+public func align(right views: [LayoutProxy]) -> [NSLayoutConstraint] {
+    return makeEqual({ $0.right }, views: views)
+}
+
 /// Aligns multiple views by their bottom edge.
 ///
 /// All views passed to this function will have
@@ -51,6 +68,10 @@ public func align(right first: LayoutProxy, _ rest: LayoutProxy...) -> [NSLayout
 ///
 public func align(bottom first: LayoutProxy, _ rest: LayoutProxy...) -> [NSLayoutConstraint] {
     return makeEqual({ $0.bottom }, first: first, rest: rest)
+}
+
+public func align(bottom views: [LayoutProxy]) -> [NSLayoutConstraint] {
+    return makeEqual({ $0.bottom }, views: views)
 }
 
 /// Aligns multiple views by their left edge.
@@ -64,6 +85,10 @@ public func align(left first: LayoutProxy, _ rest: LayoutProxy...) -> [NSLayoutC
     return makeEqual({ $0.left }, first: first, rest: rest)
 }
 
+public func align(left views: [LayoutProxy]) -> [NSLayoutConstraint] {
+    return makeEqual({ $0.left }, views: views)
+}
+
 /// Aligns multiple views by their leading edge.
 ///
 /// All views passed to this function will have
@@ -73,6 +98,10 @@ public func align(left first: LayoutProxy, _ rest: LayoutProxy...) -> [NSLayoutC
 ///
 public func align(leading first: LayoutProxy, _ rest: LayoutProxy...) -> [NSLayoutConstraint] {
     return makeEqual({ $0.leading }, first: first, rest: rest)
+}
+
+public func align(leading views: [LayoutProxy]) -> [NSLayoutConstraint] {
+    return makeEqual({ $0.leading }, views: views)
 }
 
 /// Aligns multiple vies by their trailing edge.
@@ -86,6 +115,10 @@ public func align(trailing first: LayoutProxy, _ rest: LayoutProxy...) -> [NSLay
     return makeEqual({ $0.trailing }, first: first, rest: rest)
 }
 
+public func align(trailing views: [LayoutProxy]) -> [NSLayoutConstraint] {
+    return makeEqual({ $0.trailing }, views: views)
+}
+
 /// Aligns multiple views by their horizontal center.
 ///
 /// All views passed to this function will have
@@ -95,6 +128,10 @@ public func align(trailing first: LayoutProxy, _ rest: LayoutProxy...) -> [NSLay
 ///
 public func align(centerX first: LayoutProxy, _ rest: LayoutProxy...) -> [NSLayoutConstraint] {
     return makeEqual({ $0.centerX }, first: first, rest: rest)
+}
+
+public func align(centerX views: [LayoutProxy]) -> [NSLayoutConstraint] {
+    return makeEqual({ $0.centerX }, views: views)
 }
 
 /// Aligns multiple views by their vertical center.
@@ -108,6 +145,10 @@ public func align(centerY first: LayoutProxy, _ rest: LayoutProxy...) -> [NSLayo
     return makeEqual({ $0.centerY }, first: first, rest: rest)
 }
 
+public func align(centerY views: [LayoutProxy]) -> [NSLayoutConstraint] {
+    return makeEqual({ $0.centerY }, views: views)
+}
+
 /// Aligns multiple views by their baseline.
 ///
 /// All views passed to this function will have
@@ -117,4 +158,8 @@ public func align(centerY first: LayoutProxy, _ rest: LayoutProxy...) -> [NSLayo
 ///
 public func align(baseline first: LayoutProxy, _ rest: LayoutProxy...) -> [NSLayoutConstraint] {
     return makeEqual({ $0.baseline }, first: first, rest: rest)
+}
+
+public func align(baseline views: [LayoutProxy]) -> [NSLayoutConstraint] {
+    return makeEqual({ $0.baseline }, views: views)
 }

--- a/Cartography/Distribute.swift
+++ b/Cartography/Distribute.swift
@@ -24,6 +24,17 @@ private func reduce(first: LayoutProxy, rest: [LayoutProxy], combine: (LayoutPro
     }.0
 }
 
+private func reduce(views: [LayoutProxy], combine: (LayoutProxy, LayoutProxy) -> NSLayoutConstraint) -> [NSLayoutConstraint] {
+    let (first, rest) = splitLayoutProxyArray(views)
+    rest.last?.view.car_translatesAutoresizingMaskIntoConstraints = false
+    
+    return rest.reduce(([], first)) { (acc, current) -> Accumulator in
+        let (constraints, previous) = acc
+        
+        return (constraints + [ combine(previous, current) ], current)
+        }.0
+}
+
 /// Distributes multiple views horizontally.
 ///
 /// All views passed to this function will have
@@ -36,6 +47,10 @@ private func reduce(first: LayoutProxy, rest: [LayoutProxy], combine: (LayoutPro
 ///
 public func distribute(by amount: CGFloat, horizontally first: LayoutProxy, _ rest: LayoutProxy...) -> [NSLayoutConstraint] {
     return reduce(first, rest: rest) { $0.trailing == $1.leading - amount }
+}
+
+public func distribute(by amount: CGFloat, horizontally views: [LayoutProxy]) -> [NSLayoutConstraint] {
+    return reduce(views) { $0.trailing == $1.leading - amount }
 }
 
 /// Distributes multiple views horizontally from left to right.
@@ -52,6 +67,10 @@ public func distribute(by amount: CGFloat, leftToRight first: LayoutProxy, _ res
     return reduce(first, rest: rest) { $0.right == $1.left - amount  }
 }
 
+public func distribute(by amount: CGFloat, leftToRight views: [LayoutProxy]) -> [NSLayoutConstraint] {
+    return reduce(views) { $0.right == $1.left - amount  }
+}
+
 /// Distributes multiple views vertically.
 ///
 /// All views passed to this function will have
@@ -65,3 +84,8 @@ public func distribute(by amount: CGFloat, leftToRight first: LayoutProxy, _ res
 public func distribute(by amount: CGFloat, vertically first: LayoutProxy, _ rest: LayoutProxy...) -> [NSLayoutConstraint] {
     return reduce(first, rest: rest) { $0.bottom == $1.top - amount }
 }
+
+public func distribute(by amount: CGFloat, vertically views: [LayoutProxy]) -> [NSLayoutConstraint] {
+    return reduce(views) { $0.bottom == $1.top - amount }
+}
+

--- a/Cartography/ViewUtils.swift
+++ b/Cartography/ViewUtils.swift
@@ -12,6 +12,11 @@ import UIKit
 import AppKit
 #endif
 
+internal func splitLayoutProxyArray(views: [LayoutProxy]) -> (LayoutProxy, [LayoutProxy]) {
+    var views = views
+    return (views.removeFirst(), views)
+}
+
 internal func closestCommonAncestor(a: View, b: View) -> View? {
     let (aSuper, bSuper) = (a.superview, b.superview)
 

--- a/CartographyTests/DistributeSpec.swift
+++ b/CartographyTests/DistributeSpec.swift
@@ -33,6 +33,34 @@ class DistributeSpec: QuickSpec {
                 viewA.size == viewC.size
             }
         }
+        
+        func testLeftToRightConstraints() {
+            it("should distribute the views") {
+                expect(viewA.frame.minX).to(equal(  0))
+                expect(viewB.frame.minX).to(equal(110))
+                expect(viewC.frame.minX).to(equal(220))
+            }
+            
+            it("should disable translating autoresizing masks into constraints") {
+                expect(viewA).notTo(translateAutoresizingMasksToConstraints())
+                expect(viewB).notTo(translateAutoresizingMasksToConstraints())
+                expect(viewC).notTo(translateAutoresizingMasksToConstraints())
+            }
+        }
+        
+        func testVerticalConstraints() {
+            it("should distribute the views") {
+                expect(viewA.frame.minY).to(equal(  0))
+                expect(viewB.frame.minY).to(equal(110))
+                expect(viewC.frame.minY).to(equal(220))
+            }
+            
+            it("should disable translating autoresizing masks into constraints") {
+                expect(viewA).notTo(translateAutoresizingMasksToConstraints())
+                expect(viewB).notTo(translateAutoresizingMasksToConstraints())
+                expect(viewC).notTo(translateAutoresizingMasksToConstraints())
+            }
+        }
 
         describe("from left to right") {
             beforeEach {
@@ -44,17 +72,20 @@ class DistributeSpec: QuickSpec {
                 window.layoutIfNeeded()
             }
 
-            it("should distribute the views") {
-                expect(viewA.frame.minX).to(equal(  0))
-                expect(viewB.frame.minX).to(equal(110))
-                expect(viewC.frame.minX).to(equal(220))
+            testLeftToRightConstraints()
+        }
+        
+        describe("from left to right with layout proxy array") {
+            beforeEach {
+                constrain([viewA, viewB, viewC]) { views in
+                    align(centerY: views)
+                    distribute(by: 10, leftToRight: views)
+                }
+                
+                window.layoutIfNeeded()
             }
-
-            it("should disable translating autoresizing masks into constraints") {
-                expect(viewA).notTo(translateAutoresizingMasksToConstraints())
-                expect(viewB).notTo(translateAutoresizingMasksToConstraints())
-                expect(viewC).notTo(translateAutoresizingMasksToConstraints())
-            }
+            
+            testLeftToRightConstraints()
         }
 
         describe("vertically") {
@@ -67,17 +98,20 @@ class DistributeSpec: QuickSpec {
                 window.layoutIfNeeded()
             }
 
-            it("should distribute the views") {
-                expect(viewA.frame.minY).to(equal(  0))
-                expect(viewB.frame.minY).to(equal(110))
-                expect(viewC.frame.minY).to(equal(220))
+            testVerticalConstraints()
+        }
+        
+        describe("vertically with layout proxy array") {
+            beforeEach {
+                constrain([viewA, viewB, viewC]) { views in
+                    align(centerX: views)
+                    distribute(by: 10, vertically: views)
+                }
+                
+                window.layoutIfNeeded()
             }
-
-            it("should disable translating autoresizing masks into constraints") {
-                expect(viewA).notTo(translateAutoresizingMasksToConstraints())
-                expect(viewB).notTo(translateAutoresizingMasksToConstraints())
-                expect(viewC).notTo(translateAutoresizingMasksToConstraints())
-            }
+            
+            testVerticalConstraints()
         }
     }
 }


### PR DESCRIPTION
Hello,

I'm using `constrain([views]) { x: [LayoutProxy] in ... }` and i notice that there is no support to receive an array of `[LayoutProxy]` on functions like `distribute`.

It's a known issue that swift doesn't supports splatting yet, so i can't send an array to a variadic function. [bug](https://bugs.swift.org/browse/SR-128)

It's ok to send a PR with this support?

🍻 