### PR TITLE
Priority fix and compiler bug workaround

### DIFF
--- a/Cartography/Priority.swift
+++ b/Cartography/Priority.swift
@@ -18,6 +18,7 @@ public typealias LayoutPriority = NSLayoutPriority
 
 precedencegroup CarthographyPriorityPrecedence {
     lowerThan: ComparisonPrecedence
+    higherThan: AssignmentPrecedence
 }
 
 infix operator  ~: CarthographyPriorityPrecedence

--- a/CartographyTests/PrioritySpec.swift
+++ b/CartographyTests/PrioritySpec.swift
@@ -19,8 +19,7 @@ class PrioritySpec: QuickSpec {
             var constraint: NSLayoutConstraint!
 
             constrain(view) { (view: LayoutProxy) in
-                constraint = view.width == 200
-                constraint ~ 100
+                constraint = view.width == 200 ~ 100.0
             }
 
             expect(constraint.priority).to(equal(100))


### PR DESCRIPTION
This fixes the error “PrioritySpec.swift:22:28: Adjacent operators are in unordered precedence groups 'AssignmentPrecedence' and 'CarthographyPriorityPrecedence’” noted in issue https://github.com/robb/Cartography/issues/241

It also works around the bug “PrioritySpec.swift:22:48: Cannot assign value of type 'NSLayoutConstraint' to type 'NSLayoutConstraint!’” by switching out the priority Int for a Float.

This workaround is necessary as there’s a Swift compiler bug present.

References:
https://bugs.swift.org/browse/SR-2823
https://openradar.appspot.com/28582961