### PR TITLE
Swift 3.1 @discardableResult warning of constrain(clear group: ConstraintGroup)

### DIFF
--- a/Cartography/Constrain.swift
+++ b/Cartography/Constrain.swift
@@ -141,6 +141,6 @@ import Foundation
 ///
 /// - parameter clear: The `ConstraintGroup` whose constraints should be removed.
 ///
-@discardableResult public func constrain(clear group: ConstraintGroup) {
+public func constrain(clear group: ConstraintGroup) {
     group.replaceConstraints([])
 }


### PR DESCRIPTION
New Swift 3.1 is showing warning:

Constrain.swift:144:27: @discardableResult declared on a function returning Void is unnecessary

```
/// Removes all constraints for a group.
///
/// - parameter clear: The `ConstraintGroup` whose constraints should be removed.
///
@discardableResult public func constrain(clear group: ConstraintGroup) {
    group.replaceConstraints([])
}
```