### PR TITLE
Add Safe Area Layout support

### DIFF
--- a/Cartography.xcodeproj/project.pbxproj
+++ b/Cartography.xcodeproj/project.pbxproj
@@ -122,6 +122,9 @@
 		BBAC6D141A22A3AC00E8A3E2 /* ViewUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBAC6D121A22A27900E8A3E2 /* ViewUtils.swift */; };
 		BBAC6D1B1A22A8F300E8A3E2 /* ViewHierarchySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB41A06E1A229BF7007142FE /* ViewHierarchySpec.swift */; };
 		BBAC6D1C1A22A8F400E8A3E2 /* ViewHierarchySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB41A06E1A229BF7007142FE /* ViewHierarchySpec.swift */; };
+		EE8531501F936462003EC021 /* LayoutItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE85314F1F9363DC003EC021 /* LayoutItem.swift */; };
+		EE8531521F93646A003EC021 /* LayoutItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE85314F1F9363DC003EC021 /* LayoutItem.swift */; };
+		EE8531531F94131B003EC021 /* LayoutItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE85314F1F9363DC003EC021 /* LayoutItem.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -238,6 +241,7 @@
 		825625A8CCFA9B2B102BDDDB /* Pods_TestPods_Cartography_Mac_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TestPods_Cartography_Mac_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BB41A06E1A229BF7007142FE /* ViewHierarchySpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewHierarchySpec.swift; sourceTree = "<group>"; };
 		BBAC6D121A22A27900E8A3E2 /* ViewUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewUtils.swift; sourceTree = "<group>"; };
+		EE85314F1F9363DC003EC021 /* LayoutItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutItem.swift; sourceTree = "<group>"; };
 		EEDD4098FF7503B1F9188F10 /* Pods_Cartography_iOS_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Cartography_iOS_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -387,6 +391,7 @@
 				545F858C195322EA00791F75 /* Edges.swift */,
 				546E9E941950A97F00B16707 /* Expression.swift */,
 				54B093961A7165F2008A1102 /* Extensions.swift */,
+				EE85314F1F9363DC003EC021 /* LayoutItem.swift */,
 				546E9E881950A29300B16707 /* LayoutProxy.swift */,
 				66AF7EED1CABEABC00249E27 /* LayoutSupport.swift */,
 				54FA3A3B1951A2B60094B82A /* Point.swift */,
@@ -873,6 +878,7 @@
 				54FA3A361950FD320094B82A /* Priority.swift in Sources */,
 				547BC85719E2EB9B007BEE9E /* Constraint.swift in Sources */,
 				547BC85519E2DD06007BEE9E /* Context.swift in Sources */,
+				EE8531501F936462003EC021 /* LayoutItem.swift in Sources */,
 				545F858D195322EA00791F75 /* Edges.swift in Sources */,
 				BBAC6D131A22A27900E8A3E2 /* ViewUtils.swift in Sources */,
 				546E9E8D1950A31100B16707 /* Dimension.swift in Sources */,
@@ -923,6 +929,7 @@
 				54F6A858195C213A00313D24 /* LayoutProxy.swift in Sources */,
 				54BF29B51A9350170066ED10 /* Align.swift in Sources */,
 				543B37FA1AC82FBF00367D8B /* Edge.swift in Sources */,
+				EE8531531F94131B003EC021 /* LayoutItem.swift in Sources */,
 				54F6A853195C213A00313D24 /* Compound.swift in Sources */,
 				54B093991A716A2E008A1102 /* Extensions.swift in Sources */,
 				54F6A859195C213A00313D24 /* Priority.swift in Sources */,
@@ -968,6 +975,7 @@
 				632F09381BF1F127002431A3 /* Constrain.swift in Sources */,
 				632F09391BF1F127002431A3 /* Constraint.swift in Sources */,
 				632F093A1BF1F127002431A3 /* ConstraintGroup.swift in Sources */,
+				EE8531521F93646A003EC021 /* LayoutItem.swift in Sources */,
 				632F093B1BF1F127002431A3 /* Context.swift in Sources */,
 				632F093C1BF1F127002431A3 /* Dimension.swift in Sources */,
 				632F093D1BF1F127002431A3 /* Distribute.swift in Sources */,

--- a/Cartography/Dimension.swift
+++ b/Cartography/Dimension.swift
@@ -16,10 +16,12 @@ public struct Dimension : Property, NumericalEquality, RelativeEquality, Numeric
     public let attribute: LayoutAttribute
     public let context: Context
     public let view: View
+    public let needsSafeArea: Bool
 
-    internal init(_ context: Context, _ view: View, _ attribute: LayoutAttribute) {
+    internal init(_ context: Context, _ view: View, _ attribute: LayoutAttribute, _ needsSafeArea: Bool) {
         self.attribute = attribute
         self.context = context
         self.view = view
+        self.needsSafeArea = needsSafeArea
     }
 }

--- a/Cartography/Edge.swift
+++ b/Cartography/Edge.swift
@@ -16,10 +16,12 @@ public struct Edge : Property, RelativeEquality, RelativeInequality, Addition, M
     public let attribute: LayoutAttribute
     public let context: Context
     public let view: View
+    public let needsSafeArea: Bool
 
-    internal init(_ context: Context, _ view: View, _ attribute: LayoutAttribute) {
+    internal init(_ context: Context, _ view: View, _ attribute: LayoutAttribute, _ needsSafeArea: Bool) {
         self.attribute = attribute
         self.context = context
         self.view = view
+        self.needsSafeArea = needsSafeArea
     }
 }

--- a/Cartography/LayoutItem.swift
+++ b/Cartography/LayoutItem.swift
@@ -1,0 +1,21 @@
+//
+//  LayoutItem.swift
+//  Cartography-iOS
+//
+//  Created by Yusuke Morishia on 2017/10/15.
+//  Copyright © 2017年 Robert Böhnke. All rights reserved.
+//
+#if os(iOS) || os(tvOS)
+    import UIKit
+#else
+    import AppKit
+#endif
+
+public protocol LayoutItem: class {}
+
+extension View: LayoutItem {}
+
+#if os(iOS) || os(tvOS)
+@available(iOS 9.0, tvOS 9.0, *)
+extension UILayoutGuide: LayoutItem {}
+#endif

--- a/Cartography/LayoutItem.swift
+++ b/Cartography/LayoutItem.swift
@@ -11,7 +11,7 @@
     import AppKit
 #endif
 
-public protocol LayoutItem: class {}
+internal protocol LayoutItem: class {}
 
 extension View: LayoutItem {}
 

--- a/Cartography/LayoutProxy.swift
+++ b/Cartography/LayoutProxy.swift
@@ -11,97 +11,97 @@ import Foundation
 public struct LayoutProxy {
     /// The width of the view.
     public var width: Dimension {
-        return Dimension(context, view, .width)
+        return Dimension(context, view, .width, needsSafeArea)
     }
 
     /// The height of the view.
     public var height: Dimension {
-        return Dimension(context, view, .height)
+        return Dimension(context, view, .height, needsSafeArea)
     }
 
     /// The size of the view. This property affects both `width` and `height`.
     public var size: Size {
         return Size(context, [
-            Dimension(context, view, .width),
-            Dimension(context, view, .height)
+            Dimension(context, view, .width, needsSafeArea),
+            Dimension(context, view, .height, needsSafeArea)
         ])
     }
 
     /// The top edge of the view.
     public var top: Edge {
-        return Edge(context, view, .top)
+        return Edge(context, view, .top, needsSafeArea)
     }
 
     /// The right edge of the view.
     public var right: Edge {
-        return Edge(context, view, .right)
+        return Edge(context, view, .right, needsSafeArea)
     }
 
     /// The bottom edge of the view.
     public var bottom: Edge {
-        return Edge(context, view, .bottom)
+        return Edge(context, view, .bottom, needsSafeArea)
     }
 
     /// The left edge of the view.
     public var left: Edge {
-        return Edge(context, view, .left)
+        return Edge(context, view, .left, needsSafeArea)
     }
 
     /// All edges of the view. This property affects `top`, `bottom`, `leading`
     /// and `trailing`.
     public var edges: Edges {
         return Edges(context, [
-            Edge(context, view, .top),
-            Edge(context, view, .leading),
-            Edge(context, view, .bottom),
-            Edge(context, view, .trailing)
+            Edge(context, view, .top, needsSafeArea),
+            Edge(context, view, .leading, needsSafeArea),
+            Edge(context, view, .bottom, needsSafeArea),
+            Edge(context, view, .trailing, needsSafeArea)
         ])
     }
 
     /// The leading edge of the view.
     public var leading: Edge {
-        return Edge(context, view, .leading)
+        return Edge(context, view, .leading, needsSafeArea)
     }
 
     /// The trailing edge of the view.
     public var trailing: Edge {
-        return Edge(context, view, .trailing)
+        return Edge(context, view, .trailing, needsSafeArea)
     }
 
     /// The horizontal center of the view.
     public var centerX: Edge {
-        return Edge(context, view, .centerX)
+        return Edge(context, view, .centerX, needsSafeArea)
     }
 
     /// The vertical center of the view.
     public var centerY: Edge {
-        return Edge(context, view, .centerY)
+        return Edge(context, view, .centerY, needsSafeArea)
     }
 
     /// The center point of the view. This property affects `centerX` and
     /// `centerY`.
     public var center: Point {
         return Point(context, [
-            Edge(context, view, .centerX),
-            Edge(context, view, .centerY)
+            Edge(context, view, .centerX, needsSafeArea),
+            Edge(context, view, .centerY, needsSafeArea)
         ])
     }
 
     /// The baseline of the view.
     public var baseline: Edge {
-        return Edge(context, view, .lastBaseline)
+        return Edge(context, view, .lastBaseline, needsSafeArea)
     }
 
     /// The last baseline of the view.
     public var lastBaseline: Edge {
-        return Edge(context, view, .lastBaseline)
+        return Edge(context, view, .lastBaseline, needsSafeArea)
     }
     
     #if os(iOS) || os(tvOS)
     /// The first baseline of the view. iOS exclusive.
     @available(iOS, introduced: 8.0)
     public var firstBaseline: Edge {
-        return Edge(context, view, .firstBaseline)
+        return Edge(context, view, .firstBaseline, needsSafeArea)
     }
 
     /// All edges of the view with their respective margins. This property
@@ -110,59 +110,59 @@ public struct LayoutProxy {
     @available(iOS, introduced: 8.0)
     public var edgesWithinMargins: Edges {
         return Edges(context, [
-            Edge(context, view, .topMargin),
-            Edge(context, view, .leadingMargin),
-            Edge(context, view, .bottomMargin),
-            Edge(context, view, .trailingMargin)
+            Edge(context, view, .topMargin, needsSafeArea),
+            Edge(context, view, .leadingMargin, needsSafeArea),
+            Edge(context, view, .bottomMargin, needsSafeArea),
+            Edge(context, view, .trailingMargin, needsSafeArea)
         ])
     }
 
     /// The left margin of the view. iOS exclusive.
     @available(iOS, introduced: 8.0)
     public var leftMargin: Edge {
-        return Edge(context, view, .leftMargin)
+        return Edge(context, view, .leftMargin, needsSafeArea)
     }
 
     /// The right margin of the view. iOS exclusive.
     @available(iOS, introduced: 8.0)
     public var rightMargin: Edge {
-        return Edge(context, view, .rightMargin)
+        return Edge(context, view, .rightMargin, needsSafeArea)
     }
 
     /// The top margin of the view. iOS exclusive.
     @available(iOS, introduced: 8.0)
     public var topMargin: Edge {
-        return Edge(context, view, .topMargin)
+        return Edge(context, view, .topMargin, needsSafeArea)
     }
 
     /// The bottom margin of the view. iOS exclusive.
     @available(iOS, introduced: 8.0)
     public var bottomMargin: Edge {
-        return Edge(context, view, .bottomMargin)
+        return Edge(context, view, .bottomMargin, needsSafeArea)
     }
 
     /// The leading margin of the view. iOS exclusive.
     @available(iOS, introduced: 8.0)
     public var leadingMargin: Edge {
-        return Edge(context, view, .leadingMargin)
+        return Edge(context, view, .leadingMargin, needsSafeArea)
     }
 
     /// The trailing margin of the view. iOS exclusive.
     @available(iOS, introduced: 8.0)
     public var trailingMargin: Edge {
-        return Edge(context, view, .trailingMargin)
+        return Edge(context, view, .trailingMargin, needsSafeArea)
     }
 
     /// The horizontal center within the margins of the view. iOS exclusive.
     @available(iOS, introduced: 8.0)
     public var centerXWithinMargins: Edge {
-        return Edge(context, view, .centerXWithinMargins)
+        return Edge(context, view, .centerXWithinMargins, needsSafeArea)
     }
 
     /// The vertical center within the margins of the view. iOS exclusive.
     @available(iOS, introduced: 8.0)
     public var centerYWithinMargins: Edge {
-        return Edge(context, view, .centerYWithinMargins)
+        return Edge(context, view, .centerYWithinMargins, needsSafeArea)
     }
 
     /// The center point within the margins of the view. This property affects
@@ -170,8 +170,8 @@ public struct LayoutProxy {
     @available(iOS, introduced: 8.0)
     public var centerWithinMargins: Point {
         return Point(context, [
-            Edge(context, view, .centerXWithinMargins),
-            Edge(context, view, .centerYWithinMargins)
+            Edge(context, view, .centerXWithinMargins, needsSafeArea),
+            Edge(context, view, .centerYWithinMargins, needsSafeArea)
         ])
     }
     #endif
@@ -179,6 +179,8 @@ public struct LayoutProxy {
     internal let context: Context
 
     internal let view: View
+
+    internal let needsSafeArea: Bool
 
     /// The superview of the view, if it exists.
     public var superview: LayoutProxy? {
@@ -189,8 +191,17 @@ public struct LayoutProxy {
         }
     }
 
-    init(_ context: Context, _ view: View) {
+    #if os(iOS) || os(tvOS)
+    /// The safeArea of the view.
+    @available(iOS, introduced: 11.0)
+    public var safeArea: LayoutProxy {
+        return LayoutProxy(context, view, true)
+    }
+    #endif
+
+    init(_ context: Context, _ view: View, _ needsSafeArea: Bool = false) {
         self.context = context
         self.view = view
+        self.needsSafeArea = needsSafeArea
     }
 }

--- a/Cartography/LayoutProxy.swift
+++ b/Cartography/LayoutProxy.swift
@@ -180,7 +180,7 @@ public struct LayoutProxy {
 
     internal let view: View
 
-    internal let needsSafeArea: Bool
+    private let needsSafeArea: Bool
 
     /// The superview of the view, if it exists.
     public var superview: LayoutProxy? {

--- a/Cartography/Property.swift
+++ b/Cartography/Property.swift
@@ -20,6 +20,7 @@ public protocol Property {
     var attribute: LayoutAttribute { get }
     var context: Context { get }
     var view: View { get }
+    var needsSafeArea: Bool { get }
 }
 
 // MARK: Equality

--- a/CartographyTests/DimensionSpec.swift
+++ b/CartographyTests/DimensionSpec.swift
@@ -180,5 +180,181 @@ class DimensionSpec: QuickSpec {
                 expect(view.frame.height).to(equal(200))
             }
         }
+
+#if os(iOS) || os(tvOS)
+        describe("on iOS only") {
+            beforeEach {
+                window.layoutMargins = UIEdgeInsets(top: 10, left: 20, bottom: 30, right: 40)
+            }
+
+            if #available(iOS 11.0, *) {
+                describe("LayoutProxy.safeArea.width") {
+                    it("should support relative equalities") {
+                        constrain(view) { view in
+                            view.width == view.superview!.safeArea.width
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.width).to(equal(400))
+                    }
+
+                    it("should support relative inequalities") {
+                        constrain(view) { view in
+                            view.width <= view.superview!.safeArea.width
+                            view.width >= view.superview!.safeArea.width
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.width).to(equal(400))
+                    }
+
+                    it("should support addition") {
+                        constrain(view) { view in
+                            view.width == view.superview!.safeArea.width + 100
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.width).to(equal(500))
+                    }
+
+                    it("should support subtraction") {
+                        constrain(view) { view in
+                            view.width == view.superview!.safeArea.width - 100
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.width).to(equal(300))
+                    }
+
+                    it("should support multiplication") {
+                        constrain(view) { view in
+                            view.width == view.superview!.safeArea.width * 2
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.width).to(equal(800))
+                    }
+
+                    it("should support division") {
+                        constrain(view) { view in
+                            view.width == view.superview!.safeArea.width / 2
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.width).to(equal(200))
+                    }
+
+                    it("should support complex expressions") {
+                        constrain(view) { view in
+                            view.width == view.superview!.safeArea.width / 2 + 100
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.width).to(equal(300))
+                    }
+
+                    it("should support numerical equalities") {
+                        constrain(view) { view in
+                            view.width == 200
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.width).to(equal(200))
+                    }
+                }
+
+                describe("LayoutProxy.height") {
+                    it("should support relative equalities") {
+                        constrain(view) { view in
+                            view.height == view.superview!.safeArea.height
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.height).to(equal(400))
+                    }
+
+                    it("should support relative inequalities") {
+                        constrain(view) { view in
+                            view.height <= view.superview!.safeArea.height
+                            view.height >= view.superview!.safeArea.height
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.height).to(equal(400))
+                    }
+
+                    it("should support addition") {
+                        constrain(view) { view in
+                            view.height == view.superview!.safeArea.height + 100
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.height).to(equal(500))
+                    }
+
+                    it("should support subtraction") {
+                        constrain(view) { view in
+                            view.height == view.superview!.safeArea.height - 100
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.height).to(equal(300))
+                    }
+
+                    it("should support multiplication") {
+                        constrain(view) { view in
+                            view.height == view.superview!.safeArea.height * 2
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.height).to(equal(800))
+                    }
+
+                    it("should support division") {
+                        constrain(view) { view in
+                            view.height == view.superview!.safeArea.height / 2
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.height).to(equal(200))
+                    }
+
+                    it("should support complex expressions") {
+                        constrain(view) { view in
+                            view.height == view.superview!.safeArea.height / 2 + 100
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.height).to(equal(300))
+                    }
+
+                    it("should support numerical equalities") {
+                        constrain(view) { view in
+                            view.height == 200
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.height).to(equal(200))
+                    }
+                }
+            }
+        }
+#endif
     }
 }

--- a/CartographyTests/EdgeSpec.swift
+++ b/CartographyTests/EdgeSpec.swift
@@ -371,6 +371,354 @@ class EdgeSpec: QuickSpec {
                     expect(view.frame.minX).to(equal(20))
                 }
             }
+
+            if #available(iOS 11.0, *) {
+                describe("LayoutProxy.safeArea.top") {
+                    it("should support relative equalities") {
+                        constrain(view) { view in
+                            view.top == view.superview!.safeArea.top
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.minY).to(equal(0))
+                    }
+
+                    it("should support relative inequalities") {
+                        constrain(view) { view in
+                            view.top <= view.superview!.safeArea.top
+                            view.top >= view.superview!.safeArea.top
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.minY).to(equal(0))
+                    }
+
+                    it("should support addition") {
+                        constrain(view) { view in
+                            view.top == view.superview!.safeArea.top + 100
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.minY).to(equal(100))
+                    }
+
+                    it("should support subtraction") {
+                        constrain(view) { view in
+                            view.top == view.superview!.safeArea.top - 100
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.minY).to(equal(-100))
+                    }
+                }
+
+                describe("LayoutProxy.safeArea.right") {
+                    it("should support relative equalities") {
+                        constrain(view) { view in
+                            view.right == view.superview!.safeArea.right
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.maxX).to(equal(400))
+                    }
+
+                    it("should support relative inequalities") {
+                        constrain(view) { view in
+                            view.right <= view.superview!.safeArea.right
+                            view.right >= view.superview!.safeArea.right
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.maxX).to(equal(400))
+                    }
+
+                    it("should support addition") {
+                        constrain(view) { view in
+                            view.right == view.superview!.safeArea.right + 100
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.maxX).to(equal(500))
+                    }
+
+                    it("should support subtraction") {
+                        constrain(view) { view in
+                            view.right == view.superview!.safeArea.right - 100
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.maxX).to(equal(300))
+                    }
+                }
+
+                describe("LayoutProxy.safeArea.bottom") {
+                    it("should support relative equalities") {
+                        constrain(view) { view in
+                            view.bottom == view.superview!.safeArea.bottom
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.maxY).to(equal(400))
+                    }
+
+                    it("should support relative inequalities") {
+                        constrain(view) { view in
+                            view.bottom <= view.superview!.safeArea.bottom
+                            view.bottom >= view.superview!.safeArea.bottom
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.maxY).to(equal(400))
+                    }
+
+                    it("should support addition") {
+                        constrain(view) { view in
+                            view.bottom == view.superview!.safeArea.bottom + 100
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.maxY).to(equal(500))
+                    }
+
+                    it("should support subtraction") {
+                        constrain(view) { view in
+                            view.bottom == view.superview!.safeArea.bottom - 100
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.maxY).to(equal(300))
+                    }
+                }
+
+                describe("LayoutProxy.safeArea.left") {
+                    it("should support relative equalities") {
+                        constrain(view) { view in
+                            view.left == view.superview!.safeArea.left
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.minX).to(equal(0))
+                    }
+
+                    it("should support relative inequalities") {
+                        constrain(view) { view in
+                            view.left <= view.superview!.safeArea.left
+                            view.left >= view.superview!.safeArea.left
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.minX).to(equal(0))
+                    }
+
+                    it("should support addition") {
+                        constrain(view) { view in
+                            view.left == view.superview!.safeArea.left + 100
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.minX).to(equal(100))
+                    }
+
+                    it("should support subtraction") {
+                        constrain(view) { view in
+                            view.left == view.superview!.safeArea.left - 100
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.minX).to(equal(-100))
+                    }
+                }
+
+                describe("LayoutProxy.safeArea.centerX") {
+                    it("should support relative equalities") {
+                        constrain(view) { view in
+                            view.centerX == view.superview!.safeArea.centerX
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.midX).to(equal(200))
+                    }
+
+                    it("should support relative inequalities") {
+                        constrain(view) { view in
+                            view.centerX <= view.superview!.safeArea.centerX
+                            view.centerX >= view.superview!.safeArea.centerX
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.midX).to(equal(200))
+                    }
+
+                    it("should support addition") {
+                        constrain(view) { view in
+                            view.centerX == view.superview!.safeArea.centerX + 100
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.midX).to(equal(300))
+                    }
+
+                    it("should support subtraction") {
+                        constrain(view) { view in
+                            view.centerX == view.superview!.safeArea.centerX - 100
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.midX).to(equal(100))
+                    }
+
+                    it("should support multiplication") {
+                        constrain(view) { view in
+                            view.centerX == view.superview!.safeArea.centerX * 2
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.midX).to(equal(400))
+                    }
+
+                    it("should support division") {
+                        constrain(view) { view in
+                            view.centerX == view.superview!.safeArea.centerX / 2
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.midX).to(equal(100))
+                    }
+                }
+
+                describe("LayoutProxy.safeArea.centerY") {
+                    it("should support relative equalities") {
+                        constrain(view) { view in
+                            view.centerY == view.superview!.safeArea.centerY
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.midY).to(equal(200))
+                    }
+
+                    it("should support relative inequalities") {
+                        constrain(view) { view in
+                            view.centerY <= view.superview!.safeArea.centerY
+                            view.centerY >= view.superview!.safeArea.centerY
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.midY).to(equal(200))
+                    }
+
+                    it("should support addition") {
+                        constrain(view) { view in
+                            view.centerY == view.superview!.safeArea.centerY + 100
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.midY).to(equal(300))
+                    }
+
+                    it("should support subtraction") {
+                        constrain(view) { view in
+                            view.centerY == view.superview!.safeArea.centerY - 100
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.midY).to(equal(100))
+                    }
+
+                    it("should support multiplication") {
+                        constrain(view) { view in
+                            view.centerY == view.superview!.safeArea.centerY * 2
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.midY).to(equal(400))
+                    }
+
+                    it("should support division") {
+                        constrain(view) { view in
+                            view.centerY == view.superview!.safeArea.centerY / 2
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.midY).to(equal(100))
+                    }
+                }
+
+                describe("LayoutProxy.safeArea.topMargin") {
+                    it("should support relative equalities") {
+                        constrain(view) { view in
+                            view.top == view.superview!.safeArea.topMargin
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.minY).to(equal(0))
+                    }
+                }
+
+                describe("LayoutProxy.safeArea.rightMargin") {
+                    it("should support relative equalities") {
+                        constrain(view) { view in
+                            view.right == view.superview!.safeArea.rightMargin
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.maxX).to(equal(400))
+                    }
+                }
+
+                describe("LayoutProxy.safeArea.bottomMargin") {
+                    it("should support relative equalities") {
+                        constrain(view) { view in
+                            view.bottom == view.superview!.safeArea.bottomMargin
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.maxY).to(equal(400))
+                    }
+                }
+
+                describe("LayoutProxy.safeArea.leftMargin") {
+                    it("should support relative equalities") {
+                        constrain(view) { view in
+                            view.left == view.superview!.safeArea.leftMargin
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.minX).to(equal(0))
+                    }
+                }
+            }
         }
 #endif
     }

--- a/CartographyTests/EdgesSpec.swift
+++ b/CartographyTests/EdgesSpec.swift
@@ -89,6 +89,77 @@ class EdgesSpec: QuickSpec {
                     expect(view.frame).to(equal(CGRect(x: 20, y: 10, width: 340, height: 360)))
                 }
             }
+
+            if #available(iOS 11.0, *) {
+                describe("LayoutProxy.safeArea.edges") {
+                    it("should support relative equalities") {
+                        constrain(view) { view in
+                            view.edges == view.superview!.safeArea.edges
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame).to(equal(view.superview?.frame))
+                    }
+                }
+
+                describe("LayoutProxy.edges") {
+                    it("should support relative inequalities") {
+                        constrain(view) { view in
+                            view.edges <= view.superview!.safeArea.edges
+                            view.edges >= view.superview!.safeArea.edges
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame).to(equal(view.superview?.frame))
+                    }
+                }
+
+                describe("inset") {
+                    it("should inset all edges with the same amount") {
+                        constrain(view) { view in
+                            view.edges == inset(view.superview!.safeArea.edges, 20)
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame).to(equal(CGRect(x: 20, y: 20, width: 360, height: 360)))
+                    }
+
+                    it("should inset the horizontal and vertical edge individually") {
+                        constrain(view) { view in
+                            view.edges == inset(view.superview!.safeArea.edges, 20, 30)
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame).to(equal(CGRect(x: 20, y: 30, width: 360, height: 340)))
+                    }
+
+                    it("should inset all edges individually") {
+                        constrain(view) { view in
+                            view.edges == inset(view.superview!.safeArea.edges, 10, 20, 30, 40)
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame).to(equal(CGRect(x: 20, y: 10, width: 340, height: 360)))
+                    }
+                }
+
+                describe("LayoutProxy.safeArea.edgesWithinMargins") {
+                    it("should support relative equalities") {
+                        constrain(view) { view in
+                            view.edges == view.superview!.safeArea.edgesWithinMargins
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame).to(equal(CGRect(x: 0, y: 0, width: 400, height: 400)))
+                    }
+                }
+            }
         }
         
         describe("on iOS only, inset using UIEdgeInsets") {

--- a/CartographyTests/PointSpec.swift
+++ b/CartographyTests/PointSpec.swift
@@ -71,6 +71,31 @@ class PointSpec: QuickSpec {
                     expect(view.frame).to(equal(CGRect(x: 110, y: 110, width: 200, height: 200)))
                 }
             }
+
+            if #available(iOS 11.0, *) {
+                describe("LayoutProxy.safeArea.center") {
+                    it("should support relative equalities") {
+                        constrain(view) { view in
+                            view.center == view.superview!.safeArea.center
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame).to(equal(CGRect(x: 100, y: 100, width: 200, height: 200)))
+                    }
+
+                    it("should support relative inequalities") {
+                        constrain(view) { view in
+                            view.center <= view.superview!.safeArea.center
+                            view.center >= view.superview!.safeArea.center
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame).to(equal(CGRect(x: 100, y: 100, width: 200, height: 200)))
+                    }
+                }
+            }
         }
 #endif
     }

--- a/CartographyTests/SizeSpec.swift
+++ b/CartographyTests/SizeSpec.swift
@@ -57,5 +57,58 @@ class SizeSpec: QuickSpec {
                 expect(view.frame.size).to(equal(CGSize(width: 200, height: 200)))
             }
         }
+
+        #if os(iOS) || os(tvOS)
+            describe("on iOS only") {
+                beforeEach {
+                    window.layoutMargins = UIEdgeInsets(top: 10, left: 20, bottom: 30, right: 40)
+                }
+
+            if #available(iOS 11.0, *) {
+                describe("LayoutProxy.safeArea.size") {
+                    it("should support relative equalities") {
+                        constrain(view) { view in
+                            view.size == view.superview!.safeArea.size
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.size).to(equal(CGSize(width: 400, height: 400)))
+                    }
+
+                    it("should support relative inequalities") {
+                        constrain(view) { view in
+                            view.size <= view.superview!.safeArea.size
+                            view.size >= view.superview!.safeArea.size
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.size).to(equal(CGSize(width: 400, height: 400)))
+                    }
+
+                    it("should support multiplication") {
+                        constrain(view) { view in
+                            view.size == view.superview!.safeArea.size * 2
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.size).to(equal(CGSize(width: 800, height: 800)))
+                    }
+
+                    it("should support division") {
+                        constrain(view) { view in
+                            view.size == view.superview!.safeArea.size / 2
+                        }
+
+                        window.layoutIfNeeded()
+
+                        expect(view.frame.size).to(equal(CGSize(width: 200, height: 200)))
+                    }
+                }
+            }
+        }
+#endif
     }
 }


### PR DESCRIPTION
iOS11 added the concept of [Safe Area](https://developer.apple.com/documentation/uikit/uiview/positioning_content_relative_to_the_safe_area). It would be nice to be able to use it. I supported to it using safeAreaLayoutGuide, but how about you?

