### PR TITLE
Add an overload to the priority operator ('~') that accepts a float.

### DIFF
--- a/Cartography/Priority.swift
+++ b/Cartography/Priority.swift
@@ -36,6 +36,19 @@ infix operator  ~: CarthographyPriorityPrecedence
     return lhs
 }
 
+/// Sets the priority for a constraint.
+///
+/// - parameter lhs: The constraint to update.
+/// - parameter rhs: The new priority.
+///
+/// - returns: The same constraint with its priority updated.
+///
+@discardableResult public func ~ (lhs: NSLayoutConstraint, rhs: Float) -> NSLayoutConstraint {
+    lhs.priority = LayoutPriority(rawValue: rhs)
+
+    return lhs
+}
+
 /// Sets the priority for multiple constraints.
 ///
 /// - parameter lhs: An array of `NSLayoutConstraint` instances.
@@ -44,6 +57,19 @@ infix operator  ~: CarthographyPriorityPrecedence
 /// - returns: The same constraints with their priorities updated.
 ///
 @discardableResult public func ~ (lhs: [NSLayoutConstraint], rhs: LayoutPriority) -> [NSLayoutConstraint] {
+    return lhs.map {
+        $0 ~ rhs
+    }
+}
+
+/// Sets the priority for multiple constraints.
+///
+/// - parameter lhs: An array of `NSLayoutConstraint` instances.
+/// - parameter rhs: The new priority.
+///
+/// - returns: The same constraints with their priorities updated.
+///
+@discardableResult public func ~ (lhs: [NSLayoutConstraint], rhs: Float) -> [NSLayoutConstraint] {
     return lhs.map {
         $0 ~ rhs
     }


### PR DESCRIPTION
In Swift 4, UILayoutPriority is a RawRepresentable instead of a Float, so passing numbers to the priority `~` operator no longer works out of the box.

This patch adds a function that takes a Float for the priority, and creates a UILayoutPriority from it. With this change, the Cartography DSL will stay compatible from Swift 3 to Swift 4.

Fixes the issue I opened here: #270 