### PR TITLE
README.md: fixed ~ examples to use UILayoutPriority

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,8 +196,8 @@ You can set the priorities of your constraints using the `~` operator:
 
 ```swift
 constrain(view) { view in
-    view.width  >= 200 ~ 100
-    view.height >= 200 ~ 100
+    view.width  >= 200 ~ UILayoutPriority(100)
+    view.height >= 200 ~ .required
 }
 ```
 
@@ -221,7 +221,7 @@ Note that declaring compound attributes returns multiple constraints at once:
 var constraints: [NSLayoutConstraint]?
 
 constrain(view) { view in
-    constraints = (view.size == view.superview!.size ~ 100)
+    constraints = (view.size == view.superview!.size ~ .defaultLow)
 }
 ```
 


### PR DESCRIPTION
I was about to contribute this change to support using `LayoutPriority` instead of raw values, but realized the latest version already supports this. I haven't been able to pinpoint when this changed though, all I could see is 9e2205c735aa2a4f00c8c8b0313501812cdd2414 updated some tests for it.

Edit: oh I just saw #271:
> In Swift 4, `UILayoutPriority` is a `RawRepresentable` instead of a `Float`

So that makes sense, this was a `Swift 4.0` change 👍 