### PR TITLE
Update README: fixed syntax for swift3 later

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ constrain(view, replace: group) { view in
     view.right  == view.superview!.right
 }
 
-UIView.animateWithDuration(0.5, animations: view.layoutIfNeeded)
+UIView.animate(withDuration: 0.5, animations: view.layoutIfNeeded)
 ```
 
 For convenience, the `constrain` functions also returns `ConstraintGroup`


### PR DESCRIPTION
 I fixed README. It changed from `class func animateWithDuration(duration: TimeInterval, animations: @escaping () -> Void)`  to `class func animate(withDuration duration: TimeInterval, animations: @escaping () -> Void)` since Swift 3 later.
## Reference
https://developer.apple.com/documentation/uikit/uiview/1622418-animate