### PR TITLE
xcode files with xcode9.3

### DIFF
--- a/Cartography.xcodeproj/xcshareddata/xcschemes/Cartography-Mac.xcscheme
+++ b/Cartography.xcodeproj/xcshareddata/xcschemes/Cartography-Mac.xcscheme
@@ -26,7 +26,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -47,7 +46,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Cartography.xcodeproj/xcshareddata/xcschemes/Cartography-iOS.xcscheme
+++ b/Cartography.xcodeproj/xcshareddata/xcschemes/Cartography-iOS.xcscheme
@@ -26,7 +26,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -47,7 +46,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Cartography.xcodeproj/xcshareddata/xcschemes/Cartography-tvOS.xcscheme
+++ b/Cartography.xcodeproj/xcshareddata/xcschemes/Cartography-tvOS.xcscheme
@@ -40,7 +40,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
@@ -60,7 +59,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"


### PR DESCRIPTION
If I change `Show` checkboxes in scheme management window,
xcode make these changes.

I am using this library with gitsubmodule + carthage, and add xcodeproj to xcworkspace for application development.
So these changes makes git submodule status dirty.

Please merge this.

---

P.S.
I made inverted PR for xcode9.2 previously. https://github.com/robb/Cartography/pull/284
Apple seems to delete this `language =""` behavior  in Xcode9.3 which made in Xcode9.2. 😓