### PR TITLE
Distribute width and height equally for all

### DIFF
--- a/Cartography/Distribute.swift
+++ b/Cartography/Distribute.swift
@@ -120,3 +120,55 @@
 @discardableResult public func distribute(by amount: CGFloat = 0.0, vertically first: SupportsTopLayoutProxy & SupportsBottomLayoutProxy, _ rest: (SupportsTopLayoutProxy & SupportsBottomLayoutProxy)...) -> [NSLayoutConstraint] {
     return distribute(by: amount, vertically: [first] + rest)
 }
+
+/// Distributes width for all the items.
+///
+/// All items passed to this function will have
+/// their `translatesAutoresizingMaskIntoConstraints` properties set to `false`.
+///
+/// - Parameter items: The items to distribute
+///
+/// - Returns: An array of `NSLayoutConstraint` instances
+///
+@discardableResult public func distribute(equalWidth items: [SupportsWidthLayoutProxy]) -> [NSLayoutConstraint] {
+    return reduce(items.map(AnyWidthLayoutProxy.init)) { $0.width == $1.width }
+}
+
+/// Distributes width for all the items.
+///
+/// All items passed to this function will have
+/// their `translatesAutoresizingMaskIntoConstraints` properties set to `false`.
+///
+/// - Parameter items: The items to distribute
+///
+/// - Returns: An array of `NSLayoutConstraint` instances
+///
+@discardableResult public func distribute(equalWidth first: SupportsWidthLayoutProxy, _ rest: (SupportsWidthLayoutProxy)...) -> [NSLayoutConstraint] {
+    return distribute(equalWidth: [first] + rest)
+}
+
+/// Distributes height for all the items.
+///
+/// All items passed to this function will have
+/// their `translatesAutoresizingMaskIntoConstraints` properties set to `false`.
+///
+/// - Parameter items: The items to distribute
+///
+/// - Returns: An array of `NSLayoutConstraint` instances
+///
+@discardableResult public func distribute(equalHeight items: [SupportsHeightLayoutProxy]) -> [NSLayoutConstraint] {
+    return reduce(items.map(AnyHeightLayoutProxy.init)) { $0.height == $1.height }
+}
+
+/// Distributes height for all the items.
+///
+/// All items passed to this function will have
+/// their `translatesAutoresizingMaskIntoConstraints` properties set to `false`.
+///
+/// - Parameter items: The items to distribute
+///
+/// - Returns: An array of `NSLayoutConstraint` instances
+///
+@discardableResult public func distribute(equalHeight first: SupportsHeightLayoutProxy, _ rest: (SupportsHeightLayoutProxy)...) -> [NSLayoutConstraint] {
+    return distribute(equalHeight: [first] + rest)
+}

--- a/Cartography/LayoutProxy+TypeErasure.swift
+++ b/Cartography/LayoutProxy+TypeErasure.swift
@@ -199,3 +199,35 @@ final class AnyVerticalDistributionLayoutProxy: SupportsTopLayoutProxy, Supports
         self.proxy = proxy
     }
 }
+
+final class AnyWidthLayoutProxy: SupportsWidthLayoutProxy {
+    let proxy: SupportsWidthLayoutProxy
+
+    var context: Context {
+        return proxy.context
+    }
+
+    var item: AnyObject {
+        return proxy.item
+    }
+
+    init(_ proxy: SupportsWidthLayoutProxy) {
+        self.proxy = proxy
+    }
+}
+
+final class AnyHeightLayoutProxy: SupportsHeightLayoutProxy {
+    let proxy: SupportsHeightLayoutProxy
+
+    var context: Context {
+        return proxy.context
+    }
+
+    var item: AnyObject {
+        return proxy.item
+    }
+
+    init(_ proxy: SupportsHeightLayoutProxy) {
+        self.proxy = proxy
+    }
+}

--- a/CartographyTests/DistributeSpec.swift
+++ b/CartographyTests/DistributeSpec.swift
@@ -10,6 +10,8 @@ class DistributeSpec: QuickSpec {
         var viewB: TestView!
         var viewC: TestView!
 
+        let constraintsGroup = ConstraintGroup()
+
         beforeEach {
             window = TestWindow(frame: CGRect(x: 0, y: 0, width: 400, height: 400))
 
@@ -22,7 +24,7 @@ class DistributeSpec: QuickSpec {
             viewC = TestView(frame: CGRect.zero)
             window.addSubview(viewC)
 
-            constrain(viewA, viewB, viewC) { viewA, viewB, viewC in
+            constrain(viewA, viewB, viewC, replace: constraintsGroup) { viewA, viewB, viewC in
                 viewA.width  == 100
                 viewA.height == 100
 
@@ -92,6 +94,46 @@ class DistributeSpec: QuickSpec {
             it("should have no constraints for no view") {
                 let constraints = distribute(horizontally: [])
                 expect(constraints.count).to(equal(0))
+            }
+        }
+
+        describe("When distributing width") {
+            beforeEach {
+                constrain(viewA, viewB, viewC, replace: constraintsGroup) {
+                    viewA, viewB, viewC in
+
+                    viewA.width == 50
+
+                    distribute(equalWidth: [viewA, viewB, viewC])
+                }
+
+                window.layoutIfNeeded()
+            }
+
+            it("should distribute the same width through all the views") {
+                expect(viewA.frame.width).to(equal(50))
+                expect(viewB.frame.width).to(equal(viewA.frame.width))
+                expect(viewC.frame.width).to(equal(viewB.frame.width))
+            }
+        }
+
+        describe("When distributing height") {
+            beforeEach {
+                constrain(viewA, viewB, viewC, replace: constraintsGroup) {
+                    viewA, viewB, viewC in
+
+                    viewA.height == 50
+
+                    distribute(equalHeight: [viewA, viewB, viewC])
+                }
+
+                window.layoutIfNeeded()
+            }
+
+            it("should distribute the same height through all the views") {
+                expect(viewA.frame.height).to(equal(50))
+                expect(viewB.frame.height).to(equal(viewA.frame.height))
+                expect(viewC.frame.height).to(equal(viewB.frame.height))
             }
         }
     }


### PR DESCRIPTION
Those are just two new methods to create height/width constraints within items.