### PR TITLE
Simple helper for use SafeAreaLayoutGuide if available

### DIFF
--- a/Cartography.xcodeproj/project.pbxproj
+++ b/Cartography.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		09F7751A581957EA262BC6A4 /* Pods_TestPods_Cartography_Mac_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 825625A8CCFA9B2B102BDDDB /* Pods_TestPods_Cartography_Mac_Tests.framework */; };
+		1B319C622162740100DD91D4 /* ViewProxyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B319C612162740100DD91D4 /* ViewProxyTests.swift */; };
 		40F7238205F9E56862357198 /* Pods_TestPods_Cartography_iOS_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0C63D81EB2304A489BE29E6A /* Pods_TestPods_Cartography_iOS_Tests.framework */; };
 		4A3756C91D67445F0036190E /* LayoutSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66AF7EED1CABEABC00249E27 /* LayoutSupport.swift */; };
 		54143E4E1A93991D00208182 /* Distribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5467916E1A93962000DC9BF7 /* Distribute.swift */; };
@@ -208,6 +209,7 @@
 		0827A83361EACF1E6062607E /* Pods_TestPods_Cartography_tvOS_tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TestPods_Cartography_tvOS_tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0C63D81EB2304A489BE29E6A /* Pods_TestPods_Cartography_iOS_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TestPods_Cartography_iOS_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		125531F897589C40A2E6968E /* Pods-TestPods-Cartography-iOS-Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestPods-Cartography-iOS-Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-TestPods-Cartography-iOS-Tests/Pods-TestPods-Cartography-iOS-Tests.release.xcconfig"; sourceTree = "<group>"; };
+		1B319C612162740100DD91D4 /* ViewProxyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewProxyTests.swift; sourceTree = "<group>"; };
 		3C61A3F684FD20F5E1B1F8D1 /* Pods-TestPods-Cartography-Mac-Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestPods-Cartography-Mac-Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TestPods-Cartography-Mac-Tests/Pods-TestPods-Cartography-Mac-Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		45CEEFB5D80398843533851A /* Pods-TestPods-Cartography-tvOS-tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestPods-Cartography-tvOS-tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TestPods-Cartography-tvOS-tests/Pods-TestPods-Cartography-tvOS-tests.debug.xcconfig"; sourceTree = "<group>"; };
 		5435B8B41AD8610300B805F1 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Nimble.framework; sourceTree = "<group>"; };
@@ -474,6 +476,7 @@
 				97D17CA61F8E774700C57CE1 /* ConstraintGroupSpec.swift */,
 				97D17CA81F8E774700C57CE1 /* SizeSpec.swift */,
 				97F50E531F9633AA00C6DCF5 /* ViewLayoutGuideSpec.swift */,
+				1B319C612162740100DD91D4 /* ViewProxyTests.swift */,
 			);
 			path = CartographyTests;
 			sourceTree = SOURCE_ROOT;
@@ -888,6 +891,7 @@
 			files = (
 				979558F61F97017D0096BBEA /* LayoutSupportSpec.swift in Sources */,
 				97F50E541F9633AA00C6DCF5 /* ViewLayoutGuideSpec.swift in Sources */,
+				1B319C622162740100DD91D4 /* ViewProxyTests.swift in Sources */,
 				9795590B1F9701CD0096BBEA /* ConstraintGroupSpec.swift in Sources */,
 				979559081F9701C90096BBEA /* MemoryLeakSpec.swift in Sources */,
 				979558FC1F97019E0096BBEA /* Matchers.swift in Sources */,

--- a/Cartography/ViewProxy.swift
+++ b/Cartography/ViewProxy.swift
@@ -52,3 +52,19 @@ public final class ViewProxy: SupportsPositioningLayoutProxy, SupportsBaselineLa
     }
     #endif
 }
+
+@available(iOS, introduced: 9.0)
+@available(tvOS, introduced: 9.0)
+@available(OSX, introduced: 10.11)
+@available(iOS, deprecated: 11.0, message: "The safe area is available on iOS 11+ via 'safeAreaLayoutGuide'!")
+extension ViewProxy {
+    #if os(iOS) || os(tvOS)
+    var safeArea: LayoutGuideProxy {
+        if #available(iOS 11, *), #available(tvOS 11, *) {
+            return safeAreaLayoutGuide
+        } else {
+            return layoutMarginsGuide
+        }
+    }
+    #endif
+}

--- a/Cartography/ViewProxy.swift
+++ b/Cartography/ViewProxy.swift
@@ -55,8 +55,8 @@ public final class ViewProxy: SupportsPositioningLayoutProxy, SupportsBaselineLa
 
 @available(iOS, introduced: 9.0)
 @available(tvOS, introduced: 9.0)
-@available(OSX, introduced: 10.11)
 @available(iOS, deprecated: 11.0, message: "The safe area is available on iOS 11+ via 'safeAreaLayoutGuide'!")
+@available(tvOS, deprecated: 11.0, message: "The safe area is available on tvOS 11+ via 'safeAreaLayoutGuide'!")
 extension ViewProxy {
     #if os(iOS) || os(tvOS)
     var safeArea: LayoutGuideProxy {

--- a/CartographyTests/ViewLayoutGuideSpec.swift
+++ b/CartographyTests/ViewLayoutGuideSpec.swift
@@ -12,7 +12,6 @@ import Nimble
 @testable import Cartography
 
 @available(iOS, introduced: 9.0)
-@available(iOS, introduced: 9.0)
 final class ViewLayoutGuideSpec: QuickSpec {
     override func spec() {
         describe("Layout margin guide") {

--- a/CartographyTests/ViewProxyTests.swift
+++ b/CartographyTests/ViewProxyTests.swift
@@ -1,0 +1,40 @@
+//
+//  ViewProxyTests.swift
+//  Cartography-iOS-Tests
+//
+//  Created by Luís Portela on 01/10/2018.
+//  Copyright © 2018 Robert Böhnke. All rights reserved.
+//
+
+import Nimble
+import Quick
+import UIKit
+
+@testable import Cartography
+
+@available(iOS, introduced: 9.0)
+@available(tvOS, introduced: 9.0)
+final class ViewProxyTestsSpec: QuickSpec {
+    override func spec() {
+        describe("ViewProxy SafeArea Layout Guide") {
+
+            let view: UIView = UIView(frame: .zero)
+
+            constrain(view) { testingView in
+                if #available(iOS 11, *), #available(tvOS 11, *) {
+                    context("When running on iOS 11+ devices") {
+                        it("safeArea should be SafeAreaLayoutGuide") {
+                            expect(testingView.safeArea.item).to(beIdenticalTo(testingView.safeAreaLayoutGuide.item))
+                        }
+                    }
+                } else {
+                    context("When runnig prior versions of iOS 11") {
+                        it("safeArea should be LayoutMarginsGuide") {
+                            expect(testingView.safeArea.item).to(beIdenticalTo(testingView.layoutMarginsGuide.item))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
-  - Nimble (7.3.0)
-  - Quick (1.3.1)
+  - Nimble (7.3.1)
+  - Quick (1.3.2)
 
 DEPENDENCIES:
   - Nimble (from `https://github.com/Quick/Nimble.git`)
@@ -14,15 +14,15 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   Nimble:
-    :commit: eb6130b9884d41c185b5a07cfe2181b3f9593f08
+    :commit: c72edbbd6358090f8f1c4b6141538ebc88d167d9
     :git: https://github.com/Quick/Nimble.git
   Quick:
-    :commit: 09e192455d178322f8209867d3153769d6bd7242
+    :commit: 044ea18d202369e33e1fc1849498a7824b89f1c4
     :git: https://github.com/Quick/Quick.git
 
 SPEC CHECKSUMS:
-  Nimble: 82af0668c540ed36dbf0c75c55716d0d7de41006
-  Quick: 741ba045f19fd3c783014e64882f8a72525661c8
+  Nimble: 6e4123b6d882a0f8c7f950236a3251d678cf12a2
+  Quick: 1a3fc6d2b9143276258d816c904b983a1df916a2
 
 PODFILE CHECKSUM: 5c3f231fd128c753b666a5552cc91ff9c3581a61
 


### PR DESCRIPTION
Since now we have a new safe area layout guide, it can get messy if we need to use it when compiling for iOS versions prior to 11.

This is a small helper to make it cleaner when you need to use `SafeAreaLayoutGuide`.