### PR TITLE
Add missing UIKit and AppKit imports

### DIFF
--- a/Cartography/LayoutProxy.swift
+++ b/Cartography/LayoutProxy.swift
@@ -8,6 +8,12 @@
 
 import Foundation
 
+#if os(iOS) || os(tvOS)
+import UIKit
+#elseif os(OSX)
+import AppKit
+#endif
+
 public protocol LayoutProxy: class {
     var context: Context { get }
     var item: AnyObject { get } //type-erased Layoutitem


### PR DESCRIPTION
`NSLayoutConstraint` is part of `UIKit` / `AppKit` so they need to be imported here when using alternative build systems to Xcode.