### PR TITLE
Add basic SwiftPM manifest file

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version:4.2
+import PackageDescription
+
+let package = Package(
+    name: "Cartography",
+    // platforms: [.iOS("8.0"), .macOS("10.10"), tvOS("9.0"), .watchOS("2.0")],
+    products: [
+        .library(name: "Cartography", targets: ["Cartography"])
+    ],
+    targets: [
+        .target(
+            name: "Cartography",
+            path: "Cartography"
+        )
+    ]
+)


### PR DESCRIPTION
This adds support for SwiftPM manifest based dependency managers. Specifically this adds support for installing via [Accio](https://github.com/JamitLabs/Accio) but will probably also work with SwiftPM once it's integrated into Xcode.