### PR TITLE
Xcode11 build issue fix 

### DIFF
--- a/Cartography/Constrain.swift
+++ b/Cartography/Constrain.swift
@@ -12,7 +12,7 @@ import Foundation
 ///
 /// - parameter clear: The `ConstraintGroup` whose constraints should be removed.
 ///
-public func constrain(clear group: ConstraintGroup) {
+public func cg_constrain(clear group: ConstraintGroup) {
     group.replaceConstraints([])
 }
 
@@ -23,7 +23,7 @@ public func constrain(clear group: ConstraintGroup) {
 ///                         replaced.
 /// - parameter block:      A block that declares the layout for `item`.
 ///
-@discardableResult public func constrain<A: LayoutItem>(_ item: A, replace group: ConstraintGroup = .init(), block: (A.ProxyType) -> Void) -> ConstraintGroup {
+@discardableResult public func cg_constrain<A: LayoutItem>(_ item: A, replace group: ConstraintGroup = .init(), block: (A.ProxyType) -> Void) -> ConstraintGroup {
     let proxy = item.asProxy()
 
     block(proxy)
@@ -41,7 +41,7 @@ public func constrain(clear group: ConstraintGroup) {
 ///                         replaced.
 /// - parameter block:      A block that declares the layout for `item`.
 ///
-@discardableResult public func constrain<A: LayoutItem, B: LayoutItem>(_ item1: A, _ item2: B, replace group: ConstraintGroup = .init(), block: (A.ProxyType, B.ProxyType) -> Void) -> ConstraintGroup {
+@discardableResult public func cg_constrain<A: LayoutItem, B: LayoutItem>(_ item1: A, _ item2: B, replace group: ConstraintGroup = .init(), block: (A.ProxyType, B.ProxyType) -> Void) -> ConstraintGroup {
     let ctx = Context()
 
     let proxy1 = item1.asProxy(context: ctx)
@@ -63,7 +63,7 @@ public func constrain(clear group: ConstraintGroup) {
 ///                         replaced.
 /// - parameter block:      A block that declares the layout for `item`.
 ///
-@discardableResult public func constrain<A: LayoutItem, B: LayoutItem, C: LayoutItem>(_ item1: A, _ item2: B, _ item3: C, replace group: ConstraintGroup = .init(), block: (A.ProxyType, B.ProxyType, C.ProxyType) -> Void) -> ConstraintGroup {
+@discardableResult public func cg_constrain<A: LayoutItem, B: LayoutItem, C: LayoutItem>(_ item1: A, _ item2: B, _ item3: C, replace group: ConstraintGroup = .init(), block: (A.ProxyType, B.ProxyType, C.ProxyType) -> Void) -> ConstraintGroup {
     let ctx = Context()
 
     let proxy1 = item1.asProxy(context: ctx)
@@ -87,7 +87,7 @@ public func constrain(clear group: ConstraintGroup) {
 ///                         replaced.
 /// - parameter block:      A block that declares the layout for `item`.
 ///
-@discardableResult public func constrain<A: LayoutItem, B: LayoutItem, C: LayoutItem, D: LayoutItem>(_ item1: A, _ item2: B, _ item3: C, _ item4: D, replace group: ConstraintGroup = .init(), block: (A.ProxyType, B.ProxyType, C.ProxyType, D.ProxyType) -> Void) -> ConstraintGroup {
+@discardableResult public func cg_constrain<A: LayoutItem, B: LayoutItem, C: LayoutItem, D: LayoutItem>(_ item1: A, _ item2: B, _ item3: C, _ item4: D, replace group: ConstraintGroup = .init(), block: (A.ProxyType, B.ProxyType, C.ProxyType, D.ProxyType) -> Void) -> ConstraintGroup {
     let ctx = Context()
 
     let proxy1 = item1.asProxy(context: ctx)
@@ -113,7 +113,7 @@ public func constrain(clear group: ConstraintGroup) {
 ///                         replaced.
 /// - parameter block:      A block that declares the layout for `item`.
 ///
-@discardableResult public func constrain<A: LayoutItem, B: LayoutItem, C: LayoutItem, D: LayoutItem, E: LayoutItem>(_ item1: A, _ item2: B, _ item3: C, _ item4: D, _ item5: E, replace group: ConstraintGroup = .init(), block: (A.ProxyType, B.ProxyType, C.ProxyType, D.ProxyType, E.ProxyType) -> Void) -> ConstraintGroup {
+@discardableResult public func cg_constrain<A: LayoutItem, B: LayoutItem, C: LayoutItem, D: LayoutItem, E: LayoutItem>(_ item1: A, _ item2: B, _ item3: C, _ item4: D, _ item5: E, replace group: ConstraintGroup = .init(), block: (A.ProxyType, B.ProxyType, C.ProxyType, D.ProxyType, E.ProxyType) -> Void) -> ConstraintGroup {
     let ctx = Context()
 
     let proxy1 = item1.asProxy(context: ctx)
@@ -141,7 +141,7 @@ public func constrain(clear group: ConstraintGroup) {
 ///                         replaced.
 /// - parameter block:      A block that declares the layout for `item`.
 ///
-@discardableResult public func constrain<A: LayoutItem, B: LayoutItem, C: LayoutItem, D: LayoutItem, E: LayoutItem, F: LayoutItem>(_ item1: A, _ item2: B, _ item3: C, _ item4: D, _ item5: E, _ item6: F, replace group: ConstraintGroup = .init(), block: (A.ProxyType, B.ProxyType, C.ProxyType, D.ProxyType, E.ProxyType, F.ProxyType) -> Void) -> ConstraintGroup {
+@discardableResult public func cg_constrain<A: LayoutItem, B: LayoutItem, C: LayoutItem, D: LayoutItem, E: LayoutItem, F: LayoutItem>(_ item1: A, _ item2: B, _ item3: C, _ item4: D, _ item5: E, _ item6: F, replace group: ConstraintGroup = .init(), block: (A.ProxyType, B.ProxyType, C.ProxyType, D.ProxyType, E.ProxyType, F.ProxyType) -> Void) -> ConstraintGroup {
     let ctx = Context()
 
     let proxy1 = item1.asProxy(context: ctx)
@@ -171,7 +171,7 @@ public func constrain(clear group: ConstraintGroup) {
 ///                         replaced.
 /// - parameter block:      A block that declares the layout for `item`.
 ///
-@discardableResult public func constrain<A: LayoutItem, B: LayoutItem, C: LayoutItem, D: LayoutItem, E: LayoutItem, F: LayoutItem, G: LayoutItem>(_ item1: A, _ item2: B, _ item3: C, _ item4: D, _ item5: E, _ item6: F, _ item7: G, replace group: ConstraintGroup = .init(), block: (A.ProxyType, B.ProxyType, C.ProxyType, D.ProxyType, E.ProxyType, F.ProxyType, G.ProxyType) -> Void) -> ConstraintGroup {
+@discardableResult public func cg_constrain<A: LayoutItem, B: LayoutItem, C: LayoutItem, D: LayoutItem, E: LayoutItem, F: LayoutItem, G: LayoutItem>(_ item1: A, _ item2: B, _ item3: C, _ item4: D, _ item5: E, _ item6: F, _ item7: G, replace group: ConstraintGroup = .init(), block: (A.ProxyType, B.ProxyType, C.ProxyType, D.ProxyType, E.ProxyType, F.ProxyType, G.ProxyType) -> Void) -> ConstraintGroup {
     let ctx = Context()
 
     let proxy1 = item1.asProxy(context: ctx)
@@ -203,7 +203,7 @@ public func constrain(clear group: ConstraintGroup) {
 ///                         replaced.
 /// - parameter block:      A block that declares the layout for `item`.
 ///
-@discardableResult public func constrain<A: LayoutItem, B: LayoutItem, C: LayoutItem, D: LayoutItem, E: LayoutItem, F: LayoutItem, G: LayoutItem, H: LayoutItem>(_ item1: A, _ item2: B, _ item3: C, _ item4: D, _ item5: E, _ item6: F, _ item7: G, _ item8: H, replace group: ConstraintGroup = .init(), block: (A.ProxyType, B.ProxyType, C.ProxyType, D.ProxyType, E.ProxyType, F.ProxyType, G.ProxyType, H.ProxyType) -> Void) -> ConstraintGroup {
+@discardableResult public func cg_constrain<A: LayoutItem, B: LayoutItem, C: LayoutItem, D: LayoutItem, E: LayoutItem, F: LayoutItem, G: LayoutItem, H: LayoutItem>(_ item1: A, _ item2: B, _ item3: C, _ item4: D, _ item5: E, _ item6: F, _ item7: G, _ item8: H, replace group: ConstraintGroup = .init(), block: (A.ProxyType, B.ProxyType, C.ProxyType, D.ProxyType, E.ProxyType, F.ProxyType, G.ProxyType, H.ProxyType) -> Void) -> ConstraintGroup {
     let ctx = Context()
 
     let proxy1 = item1.asProxy(context: ctx)
@@ -237,7 +237,7 @@ public func constrain(clear group: ConstraintGroup) {
 ///                         replaced.
 /// - parameter block:      A block that declares the layout for `item`.
 ///
-@discardableResult public func constrain<A: LayoutItem, B: LayoutItem, C: LayoutItem, D: LayoutItem, E: LayoutItem, F: LayoutItem, G: LayoutItem, H: LayoutItem, I: LayoutItem>(_ item1: A, _ item2: B, _ item3: C, _ item4: D, _ item5: E, _ item6: F, _ item7: G, _ item8: H, _ item9: I, replace group: ConstraintGroup = .init(), block: (A.ProxyType, B.ProxyType, C.ProxyType, D.ProxyType, E.ProxyType, F.ProxyType, G.ProxyType, H.ProxyType, I.ProxyType) -> Void) -> ConstraintGroup {
+@discardableResult public func cg_constrain<A: LayoutItem, B: LayoutItem, C: LayoutItem, D: LayoutItem, E: LayoutItem, F: LayoutItem, G: LayoutItem, H: LayoutItem, I: LayoutItem>(_ item1: A, _ item2: B, _ item3: C, _ item4: D, _ item5: E, _ item6: F, _ item7: G, _ item8: H, _ item9: I, replace group: ConstraintGroup = .init(), block: (A.ProxyType, B.ProxyType, C.ProxyType, D.ProxyType, E.ProxyType, F.ProxyType, G.ProxyType, H.ProxyType, I.ProxyType) -> Void) -> ConstraintGroup {
     let ctx = Context()
 
     let proxy1 = item1.asProxy(context: ctx)
@@ -273,7 +273,7 @@ public func constrain(clear group: ConstraintGroup) {
 ///                         replaced.
 /// - parameter block:      A block that declares the layout for `item`.
 ///
-@discardableResult public func constrain<A: LayoutItem, B: LayoutItem, C: LayoutItem, D: LayoutItem, E: LayoutItem, F: LayoutItem, G: LayoutItem, H: LayoutItem, I: LayoutItem, J: LayoutItem>(_ item1: A, _ item2: B, _ item3: C, _ item4: D, _ item5: E, _ item6: F, _ item7: G, _ item8: H, _ item9: I, _ item10: J, replace group: ConstraintGroup = .init(), block: (A.ProxyType, B.ProxyType, C.ProxyType, D.ProxyType, E.ProxyType, F.ProxyType, G.ProxyType, H.ProxyType, I.ProxyType, J.ProxyType) -> Void) -> ConstraintGroup {
+@discardableResult public func cg_constrain<A: LayoutItem, B: LayoutItem, C: LayoutItem, D: LayoutItem, E: LayoutItem, F: LayoutItem, G: LayoutItem, H: LayoutItem, I: LayoutItem, J: LayoutItem>(_ item1: A, _ item2: B, _ item3: C, _ item4: D, _ item5: E, _ item6: F, _ item7: G, _ item8: H, _ item9: I, _ item10: J, replace group: ConstraintGroup = .init(), block: (A.ProxyType, B.ProxyType, C.ProxyType, D.ProxyType, E.ProxyType, F.ProxyType, G.ProxyType, H.ProxyType, I.ProxyType, J.ProxyType) -> Void) -> ConstraintGroup {
     let ctx = Context()
 
     let proxy1 = item1.asProxy(context: ctx)
@@ -301,7 +301,7 @@ public func constrain(clear group: ConstraintGroup) {
 ///                      replaced.
 /// - parameter block:   A block that declares the layout for `items`.
 ///
-@discardableResult public func constrain<T: LayoutItem>(_ items: [T], replace group: ConstraintGroup = .init(), block: ([T.ProxyType]) -> Void) -> ConstraintGroup {
+@discardableResult public func cg_constrain<T: LayoutItem>(_ items: [T], replace group: ConstraintGroup = .init(), block: ([T.ProxyType]) -> Void) -> ConstraintGroup {
     let ctx = Context()
 
     let proxy = items.map { $0.asProxy(context: ctx) }
@@ -319,7 +319,7 @@ public func constrain(clear group: ConstraintGroup) {
 ///                      replaced.
 /// - parameter block:   A block that declares the layout for `items`.
 ///
-@discardableResult public func constrain<T, U: LayoutItem>(_ items: [T: U], replace group: ConstraintGroup = .init(), block: ([T: U.ProxyType]) -> Void) -> ConstraintGroup {
+@discardableResult public func cg_constrain<T, U: LayoutItem>(_ items: [T: U], replace group: ConstraintGroup = .init(), block: ([T: U.ProxyType]) -> Void) -> ConstraintGroup {
     let ctx = Context()
 
     let proxy: [T: U.ProxyType] = items.mapValues { $0.asProxy(context: ctx) }


### PR DESCRIPTION
Because `constrain` function is defined in `CommonUISDK` looks like XCode11 cannot compile Cartography pod anymore.
Renaming `constrain` functions to `cg_constrain` seems to fix the problem

closes: https://github.com/robb/Cartography/issues/313