### PR TITLE
Fix deprecation warning

### DIFF
--- a/Cartography/LayoutItem.swift
+++ b/Cartography/LayoutItem.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Robert Böhnke. All rights reserved.
 //
 
-public protocol LayoutItem: class {
+public protocol LayoutItem: AnyObject {
     associatedtype ProxyType: LayoutProxy
 
     func asProxy(context: Context) -> ProxyType

--- a/Cartography/LayoutProxy.swift
+++ b/Cartography/LayoutProxy.swift
@@ -14,7 +14,7 @@ import UIKit
 import AppKit
 #endif
 
-public protocol LayoutProxy: class {
+public protocol LayoutProxy: AnyObject {
     var context: Context { get }
     var item: AnyObject { get } //type-erased Layoutitem
 }


### PR DESCRIPTION
Fix warning. Using 'class' for protocol inheritance is deprecated

<img width="403" alt="Screenshot 2021-05-19 at 17 28 17" src="https://user-images.githubusercontent.com/2320840/118841180-5e4ce600-b8c8-11eb-9481-8a32dc6238a3.png">
