### PR TITLE
SUPPORTS_MACCATALYST

### DIFF
--- a/Cartography.xcodeproj/project.pbxproj
+++ b/Cartography.xcodeproj/project.pbxproj
@@ -1262,6 +1262,7 @@
 				PRODUCT_NAME = Cartography;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = YES;
 			};
 			name = Debug;
 		};
@@ -1285,6 +1286,7 @@
 				PRODUCT_NAME = Cartography;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = YES;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Added flag to the `Mac` target so it can be built for Catalyst.
This is needed when building with the future version of `Carthage` supporting Catalyst.