### PR TITLE
Fix warning when using 'class' for protocol inheritance

### DIFF
--- a/Cartography/LayoutItem.swift
+++ b/Cartography/LayoutItem.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Robert Böhnke. All rights reserved.
 //
 
-public protocol LayoutItem: class {
+public protocol LayoutItem: AnyObject {
     associatedtype ProxyType: LayoutProxy
 
     func asProxy(context: Context) -> ProxyType

--- a/Cartography/LayoutProxy.swift
+++ b/Cartography/LayoutProxy.swift
@@ -14,7 +14,7 @@ import UIKit
 import AppKit
 #endif
 
-public protocol LayoutProxy: class {
+public protocol LayoutProxy: AnyObject {
     var context: Context { get }
     var item: AnyObject { get } //type-erased Layoutitem
 }


### PR DESCRIPTION
A fresh version of https://github.com/robb/Cartography/pull/328